### PR TITLE
Feat: [BADA-69] Tailwind v4 기반 전역 스타일 및 폰트 설정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,15 +1,33 @@
 @import "tailwindcss";
 
+@import url("https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700&display=swap");
+
+/* 라이트/다크 모드 색상 설정 */
 :root {
   --background: #ffffff;
   --foreground: #171717;
-}
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  /* 폰트 */
+  --font-sans: "Pretendard", sans-serif;
+
+  /* 프로젝트 디자인 토큰 색상 */
+  --point-1: #ff5d8f;
+  --point-2: #ff87ab;
+  --point-3: #ffa6c1;
+
+  --main-1: #0f225e;
+  --main-2: #4b7aa5;
+  --main-3: #86d1eb;
+
+  --white: #ffffff;
+  --gray-light: #f6f6f6;
+  --gray: #cbcbcb;
+  --gray-mid: #9b9b9b;
+  --gray-dark: #656565;
+  --black: #222222;
+
+  --red: #ff4242;
+  --green: #11d85d;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -19,8 +37,15 @@
   }
 }
 
+/* Tailwind v4 테마 시스템용 */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-sans);
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -23,12 +12,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+    <html lang="ko">
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,0 +1,9 @@
+@import url("https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700&display=swap");
+
+:root {
+  --font-family: "Pretendard", sans-serif;
+}
+
+body {
+  font-family: var(--font-family);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,33 @@
+:root {
+  --point-1: #ff5d8f;
+  --point-2: #ff87ab;
+  --point-3: #ffa6c1;
+
+  --main-1: #0f225e;
+  --main-2: #4b7aa5;
+  --main-3: #86d1eb;
+
+  --white: #ffffff;
+  --gray-light: #f6f6f6;
+  --gray: #cbcbcb;
+  --gray-mid: #9b9b9b;
+  --gray-dark: #656565;
+  --black: #222222;
+
+  --red: #ff4242;
+  --green: #11d85d;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  background-color: var(--white);
+  color: var(--black);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,5 @@
+@import "tailwindcss/preflight";
+@import "tailwindcss/utilities";
+
+@import "../styles/font.css";
+@import "../styles/global.css";


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> #13

### 🔎 작업 내용

- [x] Tailwind v4 기반 전역 스타일 구조 설정
- [x] Pretendard 웹폰트 적용 및 CSS 변수화
- [x] 디자인 시스템 기반 색상 토큰 정의
- [x] globals.css 하나로 스타일 통합 및 최적화
- [x] 기존 font.css, global.css 제거 및 역할 통합
- [x] layout.tsx에서 불필요한 Geist 설정 제거

### 📸 스크린샷

### :loudspeaker: 전달사항

- Tailwind v4 방식에 맞게 `@tailwind` 대신 `@import "tailwindcss"` 사용
- 폰트는 Pretendard 기준으로 통일되어 적용됩니다.
- 색상, 폰트, 테마 변수는 모두 `globals.css`에서 관리됩니다.

---

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
