### PR TITLE
Feat: [BADA-55] kakao login

### DIFF
--- a/src/app/auth/kakao/callback/page.tsx
+++ b/src/app/auth/kakao/callback/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { useKakaoCallback } from '@features/auth/logics/useKakaoCallback';
+
+export default function KakaoCallbackPage() {
+  useKakaoCallback();
+
+  return <div className="p-10">로그인 처리 중입니다...</div>;
+}

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { KakaoLoginButton } from '@/shared/components/ui/KakaoLoginButton/KakaoLoginButton';
+
+export default function LandingPage() {
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <KakaoLoginButton />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,14 @@
-export default function Home() {
+'use client';
+
+import { useEffect } from 'react';
+import { useAuthStore } from '@features/auth/stores/authStore';
+
+export default function HomePage() {
+  const user = useAuthStore((state) => state.user);
+
+  useEffect(() => {
+    console.log('✅ 현재 사용자 정보:', user);
+  }, [user]);
+
   return <></>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAuthStore } from '@features/auth/stores/authStore';
 
 export default function HomePage() {
   const user = useAuthStore((state) => state.user);
+  const hasLogged = useRef(false);
 
   useEffect(() => {
-    console.log('✅ 현재 사용자 정보:', user);
+    if (user && !hasLogged.current) {
+      console.log('현재 사용자 정보:', user);
+      hasLogged.current = true;
+    }
   }, [user]);
 
   return <></>;

--- a/src/features/auth/apis/fetchKakaoAuth.ts
+++ b/src/features/auth/apis/fetchKakaoAuth.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from '@shared/lib/axiosInstance';
+import { User } from '@features/auth/types/user';
+
+interface KakaoAuthResponse {
+  accesstoken: string;
+  content: User;
+}
+
+export const fetchKakaoAuth = async (code: string): Promise<KakaoAuthResponse> => {
+  const response = await axiosInstance.get('/api/v1/auth/token/issue', {
+    params: { code, provider: 'kakao' },
+  });
+
+  return {
+    accesstoken: response.headers['accesstoken'],
+    content: response.data.content,
+  };
+};

--- a/src/features/auth/logics/useKakaoCallback.ts
+++ b/src/features/auth/logics/useKakaoCallback.ts
@@ -26,7 +26,6 @@ export const useKakaoCallback = () => {
         localStorage.setItem('accessToken', accesstoken);
         login(accesstoken, content);
 
-        console.log('✅ 사용자 정보:', content);
         router.replace(content.newUser ? '/onboarding' : '/');
       } catch (err) {
         console.error('카카오 로그인 실패', err);

--- a/src/features/auth/logics/useKakaoCallback.ts
+++ b/src/features/auth/logics/useKakaoCallback.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { fetchKakaoAuth } from '@features/auth/apis/fetchKakaoAuth';
+import { useAuthStore } from '@features/auth/stores/authStore';
+
+export const useKakaoCallback = () => {
+  const router = useRouter();
+  const login = useAuthStore((state) => state.login);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get('code');
+    if (!code) return;
+
+    const handleAuth = async () => {
+      try {
+        const { accesstoken, content } = await fetchKakaoAuth(code);
+
+        if (!accesstoken || !content) {
+          console.error('로그인 실패 - 유효하지 않은 응답');
+          return;
+        }
+
+        localStorage.setItem('accessToken', accesstoken);
+        login(accesstoken, content);
+
+        console.log('✅ 사용자 정보:', content);
+        router.replace(content.newUser ? '/onboarding' : '/');
+      } catch (err) {
+        console.error('카카오 로그인 실패', err);
+      }
+    };
+
+    handleAuth();
+  }, []);
+};

--- a/src/features/auth/logics/useKakaoLogin.ts
+++ b/src/features/auth/logics/useKakaoLogin.ts
@@ -5,7 +5,7 @@ export const useKakaoLogin = () => {
     const AUTH_URL = process.env.NEXT_PUBLIC_KAKAO_AUTH_URL;
 
     if (!REST_API_KEY || !REDIRECT_URI || !AUTH_URL) {
-      console.error('카카오 로그인 환경변수가 누락되었습니다.');
+      console.error('카카오 로그인 환경변수 누락');
       return;
     }
 

--- a/src/features/auth/logics/useKakaoLogin.ts
+++ b/src/features/auth/logics/useKakaoLogin.ts
@@ -1,0 +1,15 @@
+export const useKakaoLogin = () => {
+  return () => {
+    const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
+    const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
+    const AUTH_URL = process.env.NEXT_PUBLIC_KAKAO_AUTH_URL;
+
+    if (!REST_API_KEY || !REDIRECT_URI || !AUTH_URL) {
+      console.error('카카오 로그인 환경변수가 누락되었습니다.');
+      return;
+    }
+
+    const kakaoAuthUrl = `${AUTH_URL}?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;
+    window.location.href = kakaoAuthUrl;
+  };
+};

--- a/src/features/auth/stores/authStore.ts
+++ b/src/features/auth/stores/authStore.ts
@@ -1,10 +1,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { User } from '@features/auth/types/user';
 
 interface AuthState {
   isLoggedIn: boolean;
   accessToken: string | null;
-  login: (token: string) => void;
+  user: User | null;
+  login: (token: string, user: User) => void;
   logout: () => void;
 }
 
@@ -13,16 +15,9 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       isLoggedIn: false,
       accessToken: null,
-      login: (token) =>
-        set(() => ({
-          isLoggedIn: true,
-          accessToken: token,
-        })),
-      logout: () =>
-        set(() => ({
-          isLoggedIn: false,
-          accessToken: null,
-        })),
+      user: null,
+      login: (token, user) => set(() => ({ isLoggedIn: true, accessToken: token, user })),
+      logout: () => set(() => ({ isLoggedIn: false, accessToken: null, user: null })),
     }),
     { name: 'auth-storage' },
   ),

--- a/src/features/auth/types/user.ts
+++ b/src/features/auth/types/user.ts
@@ -1,0 +1,6 @@
+export interface User {
+  email: string;
+  name: string;
+  profile_image_url: string;
+  newUser: boolean;
+}

--- a/src/shared/components/ui/KakaoLoginButton/KakaoLoginButton.tsx
+++ b/src/shared/components/ui/KakaoLoginButton/KakaoLoginButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useKakaoLogin } from '@features/auth/logics/useKakaoLogin';
+
+export const KakaoLoginButton = () => {
+  const handleLogin = useKakaoLogin();
+
+  return (
+    <button
+      onClick={handleLogin}
+      className="w-[300px] h-[45px] bg-yellow-400 text-black rounded-md hover:bg-yellow-300 transition"
+    >
+      카카오 로그인
+    </button>
+  );
+};

--- a/src/shared/components/ui/KakaoLoginButton/index.ts
+++ b/src/shared/components/ui/KakaoLoginButton/index.ts
@@ -1,0 +1,1 @@
+export * from './KakaoLoginButton';

--- a/src/shared/components/ui/Product/Product.stories.tsx
+++ b/src/shared/components/ui/Product/Product.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Product, ProductProps } from './Product';
+import { Product, ProductProps } from '@ui/Product';
 
 const meta: Meta<typeof Product> = {
   title: 'Components/Product',

--- a/src/shared/components/ui/Product/index.ts
+++ b/src/shared/components/ui/Product/index.ts
@@ -1,0 +1,1 @@
+export * from './Product';

--- a/src/shared/components/ui/ProductInfo/ProductInfo.stories.tsx
+++ b/src/shared/components/ui/ProductInfo/ProductInfo.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ProductInfo } from './ProductInfo';
+import { ProductInfo } from '@ui/ProductInfo';
 
 const meta: Meta<typeof ProductInfo> = {
   title: 'Components/ProductInfo',


### PR DESCRIPTION
### #️⃣연관된 이슈
#8 

### 🔎 작업 내용
 - [ ]  소셜 로그인 이후 `accessToken`과 사용자 정보 상태로 저장 (`zustand + persist`)
 - [ ] 클라이언트 최초 1회만 사용자 정보 `console.log` 출력 (useRef로 중복 렌더링 방지)
 - [ ] `axios interceptor`로 `accessToken` 자동 헤더 포함 처리

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/3b71f1f3-05d7-4613-83df-c60356ae29cf)

### :loudspeaker: 전달사항
- 사용자 정보는 zustand에 저장되어 새로고침 시에도 유지됩니다.
- axiosInstance에 accessToken이 자동 삽입되므로 개별 API 호출 시 토큰 삽입이 필요 없습니다.
- 콘솔 로그는 user가 있는 경우에만 최초 1회 출력되어 디버깅 중복을 줄였습니다.

## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 🔧 다음 단계 예정
- `accessToken` 만료 시 `/api/v1/auth/token/reissue` API 연동
- `refreshToken` 만료 또는 유효하지 않은 경우 logout 처리 로직 구현