### PR TITLE
Feat: [BADA-142] 공통 컴포넌트 경로 수정 

### DIFF
--- a/src/shared/components/ui/Badge/Badge.stories.tsx
+++ b/src/shared/components/ui/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Badge } from '@ui/Badge';
 
 const meta: Meta<typeof Badge> = {

--- a/src/shared/components/ui/Badge/Badge.tsx
+++ b/src/shared/components/ui/Badge/Badge.tsx
@@ -1,5 +1,5 @@
-import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@lib/cn';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 const badgeVariants = cva(
   'inline-flex items-center justify-center rounded-full font-regular border-2 px-4 py-1 text-sm transition-colors',

--- a/src/shared/components/ui/BottomNav/BottmNav.stories.tsx
+++ b/src/shared/components/ui/BottomNav/BottmNav.stories.tsx
@@ -1,5 +1,5 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { BottomNav } from '@ui/BottomNav';
-import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof BottomNav> = {
   title: 'Components/BottomNav',

--- a/src/shared/components/ui/BottomNav/BottomNav.tsx
+++ b/src/shared/components/ui/BottomNav/BottomNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ICONS } from '@/shared/constants/iconPath';
+import { ICONS } from '@constants/iconPath';
 import { FileText, Home, Repeat, User } from 'lucide-react';
 import { useState } from 'react';
 

--- a/src/shared/components/ui/BuyButton/BuyButton.stories.tsx
+++ b/src/shared/components/ui/BuyButton/BuyButton.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { BuyButton } from '@ui/BuyButton';
 
 const meta: Meta<typeof BuyButton> = {

--- a/src/shared/components/ui/BuyButton/BuyButton.tsx
+++ b/src/shared/components/ui/BuyButton/BuyButton.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef } from 'react';
-import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '@lib/cn';
+import { cva, VariantProps } from 'class-variance-authority';
 import type { ButtonHTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 
 const buyButtonVariants = cva(
   'flex items-center justify-center font-semibold text-[20px] transition-colors rounded-lg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',

--- a/src/shared/components/ui/DataUsageCard/DataUsageCard.stories.tsx
+++ b/src/shared/components/ui/DataUsageCard/DataUsageCard.stories.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { DataUsageCard } from '@ui/DataUsageCard';
+import { useState } from 'react';
 
 const meta: Meta<typeof DataUsageCard> = {
   title: 'Components/DataUsageCard',

--- a/src/shared/components/ui/DataUsageCard/DataUsageCard.tsx
+++ b/src/shared/components/ui/DataUsageCard/DataUsageCard.tsx
@@ -1,6 +1,6 @@
-import React, { forwardRef } from 'react';
-import { cva } from 'class-variance-authority';
 import { cn } from '@lib/cn';
+import { cva } from 'class-variance-authority';
+import React, { forwardRef } from 'react';
 
 const cardWrapperVariants = cva(
   'w-[380px] h-[225px] rounded-[20px] bg-white p-4 flex flex-col justify-between shadow-sm',

--- a/src/shared/components/ui/DatePicker/DatePicker.stories.tsx
+++ b/src/shared/components/ui/DatePicker/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { DatePicker } from '@ui/DatePicker';
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof DatePicker> = {
   title: 'Components/DatePicker',

--- a/src/shared/components/ui/DatePicker/DatePicker.tsx
+++ b/src/shared/components/ui/DatePicker/DatePicker.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@lib/cn';
 import { format } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Calendar } from '@/components/ui/calendar';
-import { Button } from '@/components/ui/button';
-import { cn } from '@lib/cn';
+import * as React from 'react';
 
 export interface DatePickerProps {
   date: Date | undefined;

--- a/src/shared/components/ui/Drawer/Drawer.stories.tsx
+++ b/src/shared/components/ui/Drawer/Drawer.stories.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { Flag, Pencil, Trash2 } from 'lucide-react';
-import { Drawer, DrawerButton, FilterDrawerButton } from '@ui/Drawer';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { DataUsageCard } from '@ui/DataUsageCard';
-import type { Meta, StoryObj } from '@storybook/react';
+import { Drawer, DrawerButton, FilterDrawerButton } from '@ui/Drawer';
+import { Flag, Pencil, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
 const meta: Meta<typeof Drawer> = {
   title: 'Components/Drawer',

--- a/src/shared/components/ui/Drawer/Drawer.tsx
+++ b/src/shared/components/ui/Drawer/Drawer.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { cn } from '@lib/cn';
+import React from 'react';
 
 type DrawerVariant = 'default' | 'filter' | 'sos';
 

--- a/src/shared/components/ui/Drawer/DrawerButton.tsx
+++ b/src/shared/components/ui/Drawer/DrawerButton.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { cn } from '@lib/cn';
+import React from 'react';
 
 interface DrawerButtonProps {
   icon?: React.ReactNode;

--- a/src/shared/components/ui/Drawer/FilterDrawerButton.tsx
+++ b/src/shared/components/ui/Drawer/FilterDrawerButton.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Check } from 'lucide-react';
+import React from 'react';
 
 interface FilterDrawerButtonProps {
   children: React.ReactNode;

--- a/src/shared/components/ui/FlatTab/FlatTab.stories.tsx
+++ b/src/shared/components/ui/FlatTab/FlatTab.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { FlatTab } from '@ui/FlatTab';
 
 const sampleItems = [

--- a/src/shared/components/ui/FlatTab/FlatTab.tsx
+++ b/src/shared/components/ui/FlatTab/FlatTab.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef } from 'react';
-import { cva } from 'class-variance-authority';
-import { useFlatTab } from '@ui/FlatTab/useFlatTab';
 import { cn } from '@lib/cn';
-import type { FlatTabProps, FlatTabItem } from '@ui/FlatTab/types';
+import type { FlatTabItem, FlatTabProps } from '@ui/FlatTab/types';
+import { useFlatTab } from '@ui/FlatTab/useFlatTab';
+import { cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 
 export const flatTabVariants = cva('bg-white', {
   variants: {

--- a/src/shared/components/ui/FlatTab/types.ts
+++ b/src/shared/components/ui/FlatTab/types.ts
@@ -1,6 +1,6 @@
-import type * as React from 'react';
+import { flatTabVariants } from '@ui/FlatTab';
 import type { VariantProps } from 'class-variance-authority';
-import { flatTabVariants } from '@ui/FlatTab/FlatTab';
+import type * as React from 'react';
 
 export type FlatTabItem = {
   id: string;

--- a/src/shared/components/ui/FlatTab/useFlatTab.ts
+++ b/src/shared/components/ui/FlatTab/useFlatTab.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
 import { TabItem } from '@ui/FlatTab/types';
+import { useCallback, useEffect, useState } from 'react';
 
 export const useFlatTab = (
   items: TabItem[],

--- a/src/shared/components/ui/FloatingActionButton/FloatingActionButtion.stories.tsx
+++ b/src/shared/components/ui/FloatingActionButton/FloatingActionButtion.stories.tsx
@@ -1,6 +1,6 @@
-import { Gift, List, Pen, Plus } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { FloatingActionButton } from '@ui/FloatingActionButton';
-import type { Meta, StoryObj } from '@storybook/react';
+import { Gift, List, Pen, Plus } from 'lucide-react';
 
 const meta: Meta<typeof FloatingActionButton> = {
   title: 'Components/FloatingActionButton',

--- a/src/shared/components/ui/FloatingActionButton/FloatingActionButton.tsx
+++ b/src/shared/components/ui/FloatingActionButton/FloatingActionButton.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
 import { cn } from '@lib/cn';
+import React, { useState } from 'react';
 
 export interface FABAction {
   label: string;

--- a/src/shared/components/ui/Header/Header.stories.tsx
+++ b/src/shared/components/ui/Header/Header.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const MockLoginButton = () => (
   <button

--- a/src/shared/components/ui/Header/Header.tsx
+++ b/src/shared/components/ui/Header/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ICONS } from '@/shared/constants/iconPath';
+import { ICONS } from '@constants/iconPath';
 import { LoginButton } from '@ui/LoginButton';
 import Image from 'next/image';
 

--- a/src/shared/components/ui/Header/PageHeader.stories.tsx
+++ b/src/shared/components/ui/Header/PageHeader.stories.tsx
@@ -1,5 +1,5 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { PageHeader } from '@ui/Header';
-import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof PageHeader> = {
   title: 'Components/PageHeader',

--- a/src/shared/components/ui/ImageBox/ImageBox.stories.tsx
+++ b/src/shared/components/ui/ImageBox/ImageBox.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { ImageBox } from '@ui/ImageBox';
 
 const meta: Meta<typeof ImageBox> = {

--- a/src/shared/components/ui/ImageBox/ImageBox.tsx
+++ b/src/shared/components/ui/ImageBox/ImageBox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { cn } from '@/shared/lib/cn';
-import React from 'react';
+import { cn } from '@lib/cn';
+import Image from 'next/image';
 
 type ImageBoxSize = 'sm' | 'md' | 'lg';
 
@@ -29,7 +29,7 @@ export function ImageBox({ size = 'sm', url, className }: ImageBoxProps) {
         className,
       )}
     >
-      <img src={url || fallbackImage} alt="image" className="object-contain w-full h-full" />
+      <Image src={url || fallbackImage} alt="image" className="object-contain w-full h-full" />
     </div>
   );
 }

--- a/src/shared/components/ui/ImageCard/ImageCard.stories.tsx
+++ b/src/shared/components/ui/ImageCard/ImageCard.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { ImageCard } from '@ui/ImageCard';
 
 const meta: Meta<typeof ImageCard> = {

--- a/src/shared/components/ui/ImageCard/ImageCard.tsx
+++ b/src/shared/components/ui/ImageCard/ImageCard.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import React from 'react';
+import { useImageCard } from '@features/imageCard/hooks/useImageCard';
 import { ImageBox } from '@ui/ImageBox';
 import { LikeButton } from '@ui/LikeButton';
-import { useImageCard } from '@features/imageCard/hooks/useImageCard';
 
 interface ImageCardProps {
   size?: 'sm' | 'md' | 'lg';

--- a/src/shared/components/ui/InputField/InputField.stories.tsx
+++ b/src/shared/components/ui/InputField/InputField.stories.tsx
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { SearchIcon, TicketIcon } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { InputField } from '@ui/InputField';
+import { SearchIcon, TicketIcon } from 'lucide-react';
 import { useState } from 'react';
 
 const meta: Meta<typeof InputField> = {

--- a/src/shared/components/ui/InputField/InputField.tsx
+++ b/src/shared/components/ui/InputField/InputField.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { cn } from '@lib/cn';
 import React from 'react';
 import { InputFieldProps, inputVariants } from './index';
-import { cn } from '@lib/cn';
 
 export const InputField: React.FC<InputFieldProps> = ({
   variant = 'user',

--- a/src/shared/components/ui/LikeButton/LikeButton.stories.tsx
+++ b/src/shared/components/ui/LikeButton/LikeButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { LikeButton } from '@ui/LikeButton';
 
 const meta: Meta<typeof LikeButton> = {

--- a/src/shared/components/ui/LikeButton/LikeButton.tsx
+++ b/src/shared/components/ui/LikeButton/LikeButton.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import React from 'react';
-import { Heart } from 'lucide-react';
-import { useLike } from '@features/like/hooks/useLike';
 import { Button } from '@/components/ui/button';
+import { useLike } from '@features/like/hooks/useLike';
+import { Heart } from 'lucide-react';
 
 interface LikeButtonProps {
   defaultLiked?: boolean;

--- a/src/shared/components/ui/LoginButton/LoginButton.stories.tsx
+++ b/src/shared/components/ui/LoginButton/LoginButton.stories.tsx
@@ -1,4 +1,4 @@
-import { useAuthStore } from '@/features/auth/model/authStore';
+import { useAuthStore } from '@features/auth/model/authStore';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { LoginButton } from '@ui/LoginButton';
 import { useEffect } from 'react';

--- a/src/shared/components/ui/Product/Product.stories.tsx
+++ b/src/shared/components/ui/Product/Product.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Product, ProductProps } from '@ui/Product';
 
 const meta: Meta<typeof Product> = {

--- a/src/shared/components/ui/Product/Product.tsx
+++ b/src/shared/components/ui/Product/Product.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import React from 'react';
-import { ImageBox } from '@ui/ImageBox/ImageBox';
-import { ProductInfo } from '@ui/ProductInfo/ProductInfo';
+import { ImageBox } from '@ui/ImageBox';
+import { ProductInfo } from '@ui/ProductInfo';
 import { Heart } from 'lucide-react';
 
 export interface ProductProps {

--- a/src/shared/components/ui/ProductInfo/ProductInfo.stories.tsx
+++ b/src/shared/components/ui/ProductInfo/ProductInfo.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { ProductInfo } from '@ui/ProductInfo';
 
 const meta: Meta<typeof ProductInfo> = {

--- a/src/shared/components/ui/ProductInfo/ProductInfo.tsx
+++ b/src/shared/components/ui/ProductInfo/ProductInfo.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 
 export interface ProductInfoProps {
   brand?: string;

--- a/src/shared/components/ui/Profile/Profile.stories.tsx
+++ b/src/shared/components/ui/Profile/Profile.stories.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Profile } from '@ui/Profile';
+import { useState } from 'react';
 
 const AVATAR_URL = 'https://i.pinimg.com/originals/2f/55/97/2f559707c3b04a1964b37856f00ad608.jpg';
 

--- a/src/shared/components/ui/Profile/Profile.tsx
+++ b/src/shared/components/ui/Profile/Profile.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef } from 'react';
-import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '@lib/cn';
+import { cva, VariantProps } from 'class-variance-authority';
 import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 
 const profileVariants = cva('inline-flex items-center transition-colors', {
   variants: {

--- a/src/shared/components/ui/Review/ReviewCard.stories.tsx
+++ b/src/shared/components/ui/Review/ReviewCard.stories.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
-import { ReviewCard } from '@ui/Review/ReviewCard';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import type { ReviewCardProps } from '@ui/Review/ReviewCard';
+import { ReviewCard } from '@ui/Review/ReviewCard';
 
 const meta: Meta<typeof ReviewCard> = {
   title: 'Components/ReviewCard',

--- a/src/shared/components/ui/Review/ReviewCard.tsx
+++ b/src/shared/components/ui/Review/ReviewCard.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef } from 'react';
-import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '@lib/cn';
+import { cva, VariantProps } from 'class-variance-authority';
 import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 
 const reviewCardVariants = cva(
   'bg-white rounded-[20px] border border-gray-200 shadow-sm hover:shadow-md transition-shadow',

--- a/src/shared/components/ui/SectionDivider/SectionDivider.examples.stories.tsx
+++ b/src/shared/components/ui/SectionDivider/SectionDivider.examples.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { SectionDivider } from '@ui/SectionDivider';
 
 const meta: Meta<typeof SectionDivider> = {

--- a/src/shared/components/ui/SectionDivider/SectionDivider.stories.tsx
+++ b/src/shared/components/ui/SectionDivider/SectionDivider.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { SectionDivider } from '@ui/SectionDivider';
 
 const meta: Meta<typeof SectionDivider> = {

--- a/src/shared/components/ui/SectionDivider/SectionDivider.tsx
+++ b/src/shared/components/ui/SectionDivider/SectionDivider.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef } from 'react';
-import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '@lib/cn';
+import { cva, VariantProps } from 'class-variance-authority';
 import type { HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
 
 const sectionDividerVariants = cva('border-t border-solid', {
   variants: {

--- a/src/shared/components/ui/Slider/Slider.stories.tsx
+++ b/src/shared/components/ui/Slider/Slider.stories.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
-import { Slider } from '@ui/Slider/Slider';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Slider } from '@ui/Slider';
+import { useState } from 'react';
 
 const meta: Meta<typeof Slider> = {
   title: 'Components/Slider',

--- a/src/shared/components/ui/Slider/Slider.tsx
+++ b/src/shared/components/ui/Slider/Slider.tsx
@@ -1,13 +1,12 @@
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  forwardRef,
-  useRef,
-  type ChangeEvent,
-} from 'react';
 import { cn } from '@lib/cn';
 import type { InputHTMLAttributes } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useState,
+  type ChangeEvent
+} from 'react';
 
 export interface SliderProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {

--- a/src/shared/components/ui/Switch/Switch.stories.tsx
+++ b/src/shared/components/ui/Switch/Switch.stories.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Switch } from '@ui/Switch';
-import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 
 const meta: Meta<typeof Switch> = {
   title: 'Components/Switch',

--- a/src/shared/components/ui/Switch/Switch.tsx
+++ b/src/shared/components/ui/Switch/Switch.tsx
@@ -1,5 +1,5 @@
-import * as SwitchPrimitive from '@radix-ui/react-switch';
 import { cn } from '@lib/cn';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
 
 interface SwitchProps {
   checked: boolean;

--- a/src/shared/components/ui/TextAreaField/TextAreaField.stories.tsx
+++ b/src/shared/components/ui/TextAreaField/TextAreaField.stories.tsx
@@ -1,5 +1,5 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { TextAreaField } from '@ui/TextAreaField';
-import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof TextAreaField> = {
   title: 'Components/TextAreaField',

--- a/src/shared/components/ui/TextAreaField/TextAreaField.tsx
+++ b/src/shared/components/ui/TextAreaField/TextAreaField.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React from 'react';
 import { cn } from '@lib/cn';
+import React from 'react';
 
 interface TextAreaFieldProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   isRequired?: boolean;


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #72 

### 🔎 작업 내용

- [x] 공통 fetch 함수(fetchClient) 기반으로 API 호출 구조 통일
→ 각 API 함수에서 중복되던 fetch 설정 로직을 fetchClient로 추상화하여 일관된 요청 처리 방식 적용
- [x] API 함수 리턴 타입 명시 및 타입 안정성 강화
→ 호출 결과에 대한 타입을 명시해 컴포넌트에서 안정적으로 사용할 수 있도록 수정
- [x] 사용하지 않는 API 함수 및 주석 정리
→ 불필요하거나 중복된 API 관련 코드를 제거하여 코드 가독성과 유지보수성 향상
- [x] 에러 처리 방식 정리 및 메시지 출력 위치 통일
→ API 실패 시의 처리 방식을 한 곳에서 관리 가능하도록 구조화 (예: try/catch or fetchClient 내 처리)
- [x] authStore 또는 공통 헤더 사용 방식 통합 적용
→ 인증 헤더 등의 적용 방식을 fetchClient 내부로 이동시켜 개별 API에서 반복 작성하지 않도록 함

### 📸 스크린샷
<img width="375" height="1047" alt="image" src="https://github.com/user-attachments/assets/52bcba35-7f94-4777-a212-98c0593776c3" />

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
