### PR TITLE
Feat: [BADA-193] SortButton 컴포넌트 분리

### DIFF
--- a/src/pages/trade/data/page/DataPage.tsx
+++ b/src/pages/trade/data/page/DataPage.tsx
@@ -1,3 +1,8 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useTradePostsQuery } from '@/entities/trade-post/model/queries';
 import { useSortStateHook } from '@/shared/model/useSortStateHook';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { Header } from '@/shared/ui/Header';
@@ -8,10 +13,31 @@ import { TradeSortFilter } from '@/widgets/trade/trade-sort-filter';
 
 import { DataList } from '../ui/DataList';
 
+const SORT_OPTIONS = [
+  { value: 'latest', label: '최신순' },
+  { value: 'popular', label: '인기순' },
+];
+
 export default function DataPage() {
   const { sortOption, setSortOption, isSortDrawerOpen, openDrawer, closeDrawer } = useSortStateHook<
     'latest' | 'popular'
   >('latest');
+
+  const { posts, isLoading } = useTradePostsQuery();
+
+  const processedPosts = useMemo(() => {
+    if (!posts) return [];
+
+    const dataPosts = posts.filter((p) => p.postCategory === 'DATA');
+
+    return [...dataPosts].sort((a, b) =>
+      sortOption === 'latest'
+        ? new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        : b.likesCount - a.likesCount,
+    );
+  }, [posts, sortOption]);
+
+  const currentSortLabel = SORT_OPTIONS.find((o) => o.value === sortOption)?.label ?? '최신순';
 
   return (
     <>
@@ -22,7 +48,12 @@ export default function DataPage() {
       >
         <TradeFlatTab />
         <TradeSearchInput />
-        <DataList sortOption={sortOption} onSortClick={openDrawer} />
+        <DataList
+          items={processedPosts}
+          isLoading={isLoading}
+          sortLabel={currentSortLabel}
+          onSortClick={openDrawer}
+        />
       </BaseLayout>
       <TradeSortFilter
         isOpen={isSortDrawerOpen}

--- a/src/pages/trade/data/page/DataPage.tsx
+++ b/src/pages/trade/data/page/DataPage.tsx
@@ -1,16 +1,17 @@
+import { useSortStateHook } from '@/shared/model/useSortStateHook';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { Header } from '@/shared/ui/Header';
 import { TradeFlatTab } from '@/widgets/trade/flat-tab/ui/TradeFlatTab';
 import { TradeFloatingButton } from '@/widgets/trade/floating-button/ui/TradeFloatingButton';
 import { TradeSearchInput } from '@/widgets/trade/search-input/ui/TradeSearchInput';
 import { TradeSortFilter } from '@/widgets/trade/trade-sort-filter';
-import { useTradeSortState } from '@/widgets/trade/trade-sort-filter/model/useTradeSortState';
 
 import { DataList } from '../ui/DataList';
 
 export default function DataPage() {
-  const { sortOption, setSortOption, isSortDrawerOpen, openDrawer, closeDrawer } =
-    useTradeSortState();
+  const { sortOption, setSortOption, isSortDrawerOpen, openDrawer, closeDrawer } = useSortStateHook<
+    'latest' | 'popular'
+  >('latest');
 
   return (
     <>

--- a/src/pages/trade/data/page/DataPage.tsx
+++ b/src/pages/trade/data/page/DataPage.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 
 import { useTradePostsQuery } from '@/entities/trade-post/model/queries';
+import { DataList } from '@/pages/trade/data/ui/DataList';
 import { useSortStateHook } from '@/shared/model/useSortStateHook';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { Header } from '@/shared/ui/Header';
@@ -10,8 +11,6 @@ import { TradeFlatTab } from '@/widgets/trade/flat-tab/ui/TradeFlatTab';
 import { TradeFloatingButton } from '@/widgets/trade/floating-button/ui/TradeFloatingButton';
 import { TradeSearchInput } from '@/widgets/trade/search-input/ui/TradeSearchInput';
 import { TradeSortFilter } from '@/widgets/trade/trade-sort-filter';
-
-import { DataList } from '../ui/DataList';
 
 const SORT_OPTIONS = [
   { value: 'latest', label: '최신순' },

--- a/src/pages/trade/data/ui/DataList.tsx
+++ b/src/pages/trade/data/ui/DataList.tsx
@@ -1,38 +1,30 @@
 import { ArrowDownUp, ListFilter } from 'lucide-react';
 
-import { useTradePostsQuery } from '@/entities/trade-post/model/queries';
 import { Product } from '@/shared/ui/Product';
 
-type SortOption = 'latest' | 'popular';
+import type { AllPost } from '@/entities/trade-post/lib/types';
 
 interface DataListProps {
-  sortOption: SortOption;
+  items: AllPost[];
+  isLoading: boolean;
+  sortLabel: string;
   onSortClick: () => void;
 }
 
-export function DataList({ sortOption, onSortClick }: DataListProps) {
-  const { posts, isLoading } = useTradePostsQuery();
-
+export function DataList({ items, isLoading, sortLabel, onSortClick }: DataListProps) {
   if (isLoading) {
     return <div className="py-4 text-center text-[var(--black)]">로딩 중...</div>;
   }
-  if (!posts || posts.length === 0) {
+  if (items.length === 0) {
     return <div className="py-4 text-center text-[var(--black)]">게시물이 없습니다.</div>;
   }
-
-  const dataPosts = posts.filter((p) => p.postCategory === 'DATA');
-  const sorted = [...dataPosts].sort((a, b) =>
-    sortOption === 'latest'
-      ? new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      : b.likesCount - a.likesCount,
-  );
 
   return (
     <section className="bg-white">
       <div className="flex flex-row justify-between py-2">
         <button onClick={onSortClick} className="flex flex-row gap-1 items-center font-semibold">
           <ArrowDownUp size={16} />
-          {sortOption === 'latest' ? '최신순' : '인기순'}
+          {sortLabel}
         </button>
 
         <div className="flex flex-row gap-1 items-center font-semibold">
@@ -42,7 +34,7 @@ export function DataList({ sortOption, onSortClick }: DataListProps) {
       </div>
 
       <div className="flex flex-col gap-4">
-        {sorted.map((item) => (
+        {items.map((item) => (
           <Product
             key={item.id}
             name={item.title}

--- a/src/pages/trade/data/ui/DataList.tsx
+++ b/src/pages/trade/data/ui/DataList.tsx
@@ -1,6 +1,7 @@
-import { ArrowDownUp, ListFilter } from 'lucide-react';
+import { ListFilter } from 'lucide-react';
 
 import { Product } from '@/shared/ui/Product';
+import { SortButton } from '@/shared/ui/SortButton';
 
 import type { AllPost } from '@/entities/trade-post/lib/types';
 
@@ -22,10 +23,7 @@ export function DataList({ items, isLoading, sortLabel, onSortClick }: DataListP
   return (
     <section className="bg-white">
       <div className="flex flex-row justify-between py-2">
-        <button onClick={onSortClick} className="flex flex-row gap-1 items-center font-semibold">
-          <ArrowDownUp size={16} />
-          {sortLabel}
-        </button>
+        <SortButton label={sortLabel} onClick={onSortClick} />
 
         <div className="flex flex-row gap-1 items-center font-semibold">
           조건

--- a/src/pages/trade/gifticon/page/GifticonPage.tsx
+++ b/src/pages/trade/gifticon/page/GifticonPage.tsx
@@ -4,18 +4,19 @@ import { useState } from 'react';
 
 import { GifticonFilter } from '@/pages/trade/gifticon/ui/GifticonFilter';
 import { GifticonList } from '@/pages/trade/gifticon/ui/GifticonList';
+import { useSortStateHook } from '@/shared/model/useSortStateHook';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { Header } from '@/shared/ui/Header';
 import { TradeFlatTab } from '@/widgets/trade/flat-tab/ui/TradeFlatTab';
 import { TradeFloatingButton } from '@/widgets/trade/floating-button/ui/TradeFloatingButton';
 import { TradeSearchInput } from '@/widgets/trade/search-input/ui/TradeSearchInput';
 import { TradeSortFilter } from '@/widgets/trade/trade-sort-filter';
-import { useTradeSortState } from '@/widgets/trade/trade-sort-filter/model/useTradeSortState';
 
 export default function GifticonPage() {
   const [selectedCategory, setSelectedCategory] = useState<string>('전체');
-  const { sortOption, setSortOption, isSortDrawerOpen, openDrawer, closeDrawer } =
-    useTradeSortState();
+  const { sortOption, setSortOption, isSortDrawerOpen, openDrawer, closeDrawer } = useSortStateHook<
+    'latest' | 'popular'
+  >('latest');
 
   return (
     <>

--- a/src/pages/trade/gifticon/page/GifticonPage.tsx
+++ b/src/pages/trade/gifticon/page/GifticonPage.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
+import { useTradePostsQuery } from '@/entities/trade-post/model/queries';
 import { GifticonFilter } from '@/pages/trade/gifticon/ui/GifticonFilter';
 import { GifticonList } from '@/pages/trade/gifticon/ui/GifticonList';
 import { useSortStateHook } from '@/shared/model/useSortStateHook';
@@ -12,12 +13,36 @@ import { TradeFloatingButton } from '@/widgets/trade/floating-button/ui/TradeFlo
 import { TradeSearchInput } from '@/widgets/trade/search-input/ui/TradeSearchInput';
 import { TradeSortFilter } from '@/widgets/trade/trade-sort-filter';
 
+const SORT_OPTIONS = [
+  { value: 'latest', label: '최신순' },
+  { value: 'popular', label: '인기순' },
+];
+
 export default function GifticonPage() {
   const [selectedCategory, setSelectedCategory] = useState<string>('전체');
   const { sortOption, setSortOption, isSortDrawerOpen, openDrawer, closeDrawer } = useSortStateHook<
     'latest' | 'popular'
   >('latest');
 
+  const { posts, isLoading } = useTradePostsQuery();
+
+  const processedPosts = useMemo(() => {
+    if (!posts) return [];
+
+    const gifticonPosts = posts.filter((p) => p.postCategory === 'GIFTICON');
+
+    const filtered = gifticonPosts.filter(
+      (p) => selectedCategory === '전체' || p.gifticonCategory === selectedCategory,
+    );
+
+    return [...filtered].sort((a, b) =>
+      sortOption === 'latest'
+        ? new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        : b.likesCount - a.likesCount,
+    );
+  }, [posts, selectedCategory, sortOption]);
+
+  const currentSortLabel = SORT_OPTIONS.find((o) => o.value === sortOption)?.label ?? '최신순';
   return (
     <>
       <BaseLayout
@@ -32,9 +57,10 @@ export default function GifticonPage() {
           onSelectCategory={setSelectedCategory}
         />
         <GifticonList
-          sortOption={sortOption}
+          items={processedPosts}
+          isLoading={isLoading}
+          sortLabel={currentSortLabel}
           onSortClick={openDrawer}
-          selectedCategory={selectedCategory}
         />
       </BaseLayout>
       <TradeSortFilter

--- a/src/pages/trade/gifticon/ui/GifticonList.tsx
+++ b/src/pages/trade/gifticon/ui/GifticonList.tsx
@@ -1,43 +1,30 @@
 import { ListFilter } from 'lucide-react';
 
-import { useTradePostsQuery } from '@/entities/trade-post/model/queries';
 import { Product } from '@/shared/ui/Product';
 import { SortButton } from '@/shared/ui/SortButton';
 
-type SortOption = 'latest' | 'popular';
+import type { AllPost } from '@/entities/trade-post/lib/types';
 
 interface GifticonListProps {
-  sortOption: SortOption;
+  items: AllPost[];
+  isLoading: boolean;
+  sortLabel: string;
   onSortClick: () => void;
-  selectedCategory: string;
 }
 
-export function GifticonList({ sortOption, onSortClick, selectedCategory }: GifticonListProps) {
-  const { posts, isLoading } = useTradePostsQuery();
-
+export function GifticonList({ items, isLoading, sortLabel, onSortClick }: GifticonListProps) {
   if (isLoading) {
     return <div>로딩 중...</div>;
   }
 
-  if (!posts || posts.length === 0) {
+  if (items.length === 0) {
     return <div>쿠폰 게시물이 없습니다.</div>;
   }
-  const gifticonPosts = posts.filter((p) => p.postCategory === 'GIFTICON');
-
-  const filtered = gifticonPosts.filter(
-    (p) => selectedCategory === '전체' || p.gifticonCategory === selectedCategory,
-  );
-
-  const sorted = [...filtered].sort((a, b) =>
-    sortOption === 'latest'
-      ? new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      : b.likesCount - a.likesCount,
-  );
 
   return (
     <section className="bg-white">
       <div className="flex flex-row justify-between py-2">
-        <SortButton onClick={onSortClick} label={sortOption === 'latest' ? '최신순' : '인기순'} />
+        <SortButton onClick={onSortClick} label={sortLabel} />
 
         <div className="flex flex-row gap-1 items-center font-semibold">
           조건
@@ -46,7 +33,7 @@ export function GifticonList({ sortOption, onSortClick, selectedCategory }: Gift
       </div>
 
       <div className="flex flex-col gap-4 py-4">
-        {sorted.map((item) => (
+        {items.map((item) => (
           <Product
             key={item.id}
             brand={item.partner}

--- a/src/pages/trade/gifticon/ui/GifticonList.tsx
+++ b/src/pages/trade/gifticon/ui/GifticonList.tsx
@@ -1,7 +1,8 @@
-import { ArrowDownUp, ListFilter } from 'lucide-react';
+import { ListFilter } from 'lucide-react';
 
 import { useTradePostsQuery } from '@/entities/trade-post/model/queries';
 import { Product } from '@/shared/ui/Product';
+import { SortButton } from '@/shared/ui/SortButton';
 
 type SortOption = 'latest' | 'popular';
 
@@ -36,10 +37,7 @@ export function GifticonList({ sortOption, onSortClick, selectedCategory }: Gift
   return (
     <section className="bg-white">
       <div className="flex flex-row justify-between py-2">
-        <button onClick={onSortClick} className="flex flex-row gap-1 items-center font-semibold">
-          <ArrowDownUp size={16} />
-          {sortOption === 'latest' ? '최신순' : '인기순'}
-        </button>
+        <SortButton onClick={onSortClick} label={sortOption === 'latest' ? '최신순' : '인기순'} />
 
         <div className="flex flex-row gap-1 items-center font-semibold">
           조건

--- a/src/shared/model/useSortStateHook.ts
+++ b/src/shared/model/useSortStateHook.ts
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 
-export function useTradeSortState() {
-  const [sortOption, setSortOption] = useState<'latest' | 'popular'>('latest');
+/**
+ * 범용 정렬 상태 관리 훅
+ * @param defaultOption - 기본 정렬 옵션 값
+ */
+
+export function useSortStateHook<T extends string>(defaultOption: T) {
+  const [sortOption, setSortOption] = useState<T>(defaultOption);
   const [isSortDrawerOpen, setIsSortDrawerOpen] = useState(false);
 
   return {

--- a/src/shared/ui/SortButton/SortButton.tsx
+++ b/src/shared/ui/SortButton/SortButton.tsx
@@ -1,0 +1,19 @@
+import { ArrowDownUp } from 'lucide-react';
+
+interface SortButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+export function SortButton({ label, onClick }: SortButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-row gap-1 items-center font-semibold"
+    >
+      <ArrowDownUp size={16} />
+      {label}
+    </button>
+  );
+}

--- a/src/shared/ui/SortButton/index.ts
+++ b/src/shared/ui/SortButton/index.ts
@@ -1,0 +1,1 @@
+export * from './SortButton';


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #111 

### 🔎 작업 내용

- [x] 거래 페이지 데이터/기프티콘 페이지 구조 개선
- [x] `SortButton` 컴포넌트 분리
- [x] `useSortStateHook`을 제너릭으로 변경하여 범용성 개선

### 📸 스크린샷

### :loudspeaker: 전달사항
- `src/pages/trade/gifticon/page/GifticonPage.tsx`
- `src/pages/trade/gifticon/ui/GifticonList.tsx`
- `src/shared/model/useSortStateHook.ts`
- `src/widgets/trade/trade-sort-filter/ui/TradeSortFilter.tsx`
- `src/shared/ui/SortButton/SortButton.tsx`

`SortButton` 사용시 위 파일들 참고 부탁드립니다~~

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
