### PR TITLE
Feat: [BADA-212] 대여_예약 탭 UI

### DIFF
--- a/src/app/rental/[storeId]/reservation/page.tsx
+++ b/src/app/rental/[storeId]/reservation/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import ReservationPage from '@/pages/rental/store/reservation/page/ReservationPage';
+
+export default function Page() {
+  return <ReservationPage />;
+}

--- a/src/pages/rental/map/__mocks__/reservationDeviceCard.mock.ts
+++ b/src/pages/rental/map/__mocks__/reservationDeviceCard.mock.ts
@@ -1,0 +1,5 @@
+export const mockDevices = [
+  { id: 1, name: '기기 이름', price: '10,000원', image: '' },
+  { id: 2, name: '기기 이름', price: '10,000원', image: '' },
+  { id: 3, name: '기기 이름', price: '10,000원', image: '' },
+];

--- a/src/pages/rental/map/__mocks__/reservationDeviceCard.mock.ts
+++ b/src/pages/rental/map/__mocks__/reservationDeviceCard.mock.ts
@@ -1,5 +1,36 @@
-export const mockDevices = [
-  { id: 1, name: '기기 이름', price: '10,000원', image: '' },
-  { id: 2, name: '기기 이름', price: '10,000원', image: '' },
-  { id: 3, name: '기기 이름', price: '10,000원', image: '' },
+export const mockReservationDevices = [
+  {
+    id: 1,
+    deviceName: '포켓 와이파이 기기 A',
+    imageUrl:
+      'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=400&q=80',
+    dataCapacity: 2,
+    price: 1900,
+    remainCount: 3,
+  },
+  {
+    id: 2,
+    deviceName: '포켓 와이파이 기기 B',
+    imageUrl:
+      'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=400&q=80',
+    dataCapacity: 2,
+    price: 2000,
+    remainCount: 5,
+  },
+  {
+    id: 3,
+    deviceName: '포켓 와이파이 기기 C',
+    imageUrl: '/assets/trade-sample.png',
+    dataCapacity: 2,
+    price: 2400,
+    remainCount: 2,
+  },
+  {
+    id: 4,
+    deviceName: '포켓 와이파이 기기 B',
+    imageUrl: '/assets/trade-sample.png',
+    dataCapacity: 2,
+    price: 1900,
+    remainCount: 0,
+  },
 ];

--- a/src/pages/rental/map/ui/DeviceImage.tsx
+++ b/src/pages/rental/map/ui/DeviceImage.tsx
@@ -1,23 +1,18 @@
-import Image from 'next/image';
-
 interface DeviceImageProps {
   url: string;
-  alt?: string;
+  alt: string;
   className?: string;
 }
 
-export default function DeviceImage({ url, alt = 'device', className }: DeviceImageProps) {
-  return (
-    <div className={`relative w-full h-full ${className ?? ''}`}>
-      <Image
-        src={url}
-        alt={alt}
-        fill
-        className="object-cover m-0 p-0 block"
-        draggable={false}
-        sizes="100vw"
-        priority
-      />
-    </div>
-  );
-}
+const DeviceImage = ({ url, alt, className }: DeviceImageProps) => (
+  <img
+    src={
+      url ||
+      'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=400&q=80'
+    }
+    alt={alt}
+    className={className}
+  />
+);
+
+export default DeviceImage;

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -12,7 +12,7 @@ interface ReservationDeviceCardProps {
   count?: number;
   onCountChange?: (newCount: number) => void;
   selected?: boolean;
-  onClick?: () => void;
+  max?: number;
 }
 
 const CARD_SIZE = {
@@ -28,24 +28,20 @@ export default function ReservationDeviceCard({
   count = 0,
   onCountChange = () => {},
   selected,
-  onClick,
+  max = 99,
 }: ReservationDeviceCardProps) {
   const sz = CARD_SIZE;
   const { deviceName, imageUrl, dataCapacity, price, remainCount } = device;
-
+  const canIncrement = count < (max ?? 99);
   return (
     <div
       className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
-        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)] '} flex-shrink-0 min-w-[270px]`}
-      onClick={onClick}
-      style={{ cursor: onClick ? 'pointer' : undefined }}
+        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px]`}
+      style={{ cursor: 'default' }}
     >
       <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden`}>
         <DeviceImage
-          url={
-            imageUrl ||
-            'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=400&q=80'
-          }
+          url={imageUrl ?? ''}
           alt={deviceName ?? ''}
           className={`w-full h-full object-cover ${sz.imgRadius}`}
         />
@@ -75,17 +71,23 @@ export default function ReservationDeviceCard({
                 onCountChange(Math.max(0, count - 1));
               }}
               type="button"
+              disabled={count <= 0}
             >
               –
             </button>
-            <span className="font-label-semibold text-black w-6 text-center">{count}</span>
+            <span
+              className={`font-label-semibold w-6 text-center ${count > 0 ? 'text-[var(--main-5)]' : 'text-black'}`}
+            >
+              {count}
+            </span>
             <button
-              className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
+              className={`w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center ${!canIncrement ? 'opacity-50 cursor-not-allowed' : ''}`}
               onClick={(e) => {
                 e.stopPropagation();
                 onCountChange(count + 1);
               }}
               type="button"
+              disabled={!canIncrement}
             >
               +
             </button>

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -1,41 +1,97 @@
-import React from 'react';
+import DeviceImage from '@/pages/rental/map/ui/DeviceImage';
 
 interface ReservationDeviceCardProps {
-  name: string;
-  price: string;
-  image?: string;
+  device: {
+    deviceName?: string;
+    imageUrl?: string;
+    dataCapacity?: number | string;
+    price?: number;
+    remainCount?: number;
+    id?: number;
+  };
+  count?: number;
+  onCountChange?: (newCount: number) => void;
   selected?: boolean;
   onClick?: () => void;
 }
 
-const ReservationDeviceCard: React.FC<ReservationDeviceCardProps> = ({
-  name,
-  price,
-  image,
+const CARD_SIZE = {
+  w: 'w-[270px]',
+  h: 'h-[230px]',
+  img: 'h-[135px]',
+  radius: 'rounded-[20px]', // 카드 전체 radius
+  imgRadius: 'rounded-t-[20px]', // 이미지 상단 radius 동일하게
+};
+
+export default function ReservationDeviceCard({
+  device,
+  count = 0,
+  onCountChange = () => {},
   selected,
   onClick,
-}) => (
-  <div
-    className={`min-w-[180px] max-w-[180px] h-[180px] flex flex-col items-start cursor-pointer
-      ${selected ? 'border-2 border-[var(--main-5)]' : 'border border-transparent'}`}
-    onClick={onClick}
-  >
-    <div
-      className="w-full h-[140px] rounded-[28px] mb-2 flex items-center justify-center overflow-hidden"
-      style={{
-        backgroundImage:
-          'linear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%),\nlinear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%)',
-        backgroundSize: '32px 32px',
-        backgroundPosition: '0 0, 16px 16px',
-      }}
-    >
-      {image ? <img src={image} alt={name} className="object-contain w-full h-full" /> : null}
-    </div>
-    <div className="w-full text-left">
-      <div className="font-title-semibold text-black">{name}</div>
-      <div className="font-label-regular text-black">{price}</div>
-    </div>
-  </div>
-);
+}: ReservationDeviceCardProps) {
+  const sz = CARD_SIZE;
+  const { deviceName, imageUrl, dataCapacity, price, remainCount } = device;
 
-export default ReservationDeviceCard;
+  return (
+    <div
+      className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
+        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)] '} flex-shrink-0 min-w-[270px]`}
+      onClick={onClick}
+      style={{ cursor: onClick ? 'pointer' : undefined }}
+    >
+      <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden`}>
+        <DeviceImage
+          url={
+            imageUrl ||
+            'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=400&q=80'
+          }
+          alt={deviceName ?? ''}
+          className={`w-full h-full object-cover ${sz.imgRadius}`}
+        />
+      </div>
+      {/* 정보 영역 */}
+      <div className="flex flex-col px-4 py-3 flex-1">
+        <div className="flex items-center justify-between w-full mb-1">
+          <span className="text-black">
+            <span className="font-label-regular">매일 </span>
+            <span className="font-label-semibold">{dataCapacity}GB</span>
+          </span>
+          <span className="font-label-regular text-right text-[var(--main-5)]">
+            남은 공유기 <span className="font-label-semibold">{remainCount}대</span>
+          </span>
+        </div>
+        <div className="font-label-semibold text-black mb-1">{deviceName}</div>
+        {/* 가격 + 수량조절 한 줄에 */}
+        <div className="flex items-center justify-between mb-2">
+          <div className="font-label-semibold text-[var(--main-5)]">
+            {typeof price === 'number' ? `${price.toLocaleString()}원` : '-'}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCountChange(Math.max(0, count - 1));
+              }}
+              type="button"
+            >
+              –
+            </button>
+            <span className="font-label-semibold text-black w-6 text-center">{count}</span>
+            <button
+              className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCountChange(count + 1);
+              }}
+              type="button"
+            >
+              +
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface DeviceCardProps {
+  name: string;
+  price: string;
+  image?: string;
+}
+
+export const DeviceCard: React.FC<DeviceCardProps> = ({ name, price, image }) => {
+  return (
+    <div className="min-w-[180px] max-w-[180px] h-[180px] flex flex-col items-start">
+      <div
+        className="w-full h-[140px] rounded-[28px] mb-2 flex items-center justify-center overflow-hidden"
+        style={{
+          backgroundImage:
+            'linear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%),\nlinear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%)',
+          backgroundSize: '32px 32px',
+          backgroundPosition: '0 0, 16px 16px',
+        }}
+      >
+        {image ? <img src={image} alt={name} className="object-contain w-full h-full" /> : null}
+      </div>
+      <div className="w-full text-left">
+        <div className="font-bold text-lg leading-tight">{name}</div>
+        <div className="text-base mt-1">{price}</div>
+      </div>
+    </div>
+  );
+};
+
+export default DeviceCard;

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { BellRing } from 'lucide-react';
 
@@ -15,7 +15,7 @@ interface ReservationDeviceCardProps {
     id?: number;
   };
   count?: number;
-  onCountChange?: (newCount: number) => void;
+  onCountChange?: (id: number, newCount: number, remainCount: number) => void;
   selected?: boolean;
   max?: number;
 }
@@ -28,121 +28,131 @@ const CARD_SIZE = {
   imgRadius: 'rounded-t-[20px]',
 };
 
-export default function ReservationDeviceCard({
-  device,
-  count = 0,
-  onCountChange = () => {},
-  selected,
-  max = 99,
-}: ReservationDeviceCardProps) {
-  const sz = CARD_SIZE;
-  const { deviceName, imageUrl, dataCapacity, price, remainCount } = device;
-  const canIncrement = count < (max ?? 99);
-  const isSoldOut = (remainCount ?? 0) === 0;
-  const [notifyActive, setNotifyActive] = React.useState(false);
+const ReservationDeviceCard: React.FC<ReservationDeviceCardProps> = React.memo(
+  ({ device, count = 0, onCountChange = () => {}, selected, max = 99 }) => {
+    const sz = CARD_SIZE;
+    const { deviceName, imageUrl, dataCapacity, price, remainCount, id } = device;
+    const canIncrement = count < (max ?? 99);
+    const isSoldOut = (remainCount ?? 0) === 0;
+    const [notifyActive, setNotifyActive] = useState(false);
 
-  const handleNotifyToggle = () => {
-    if (!notifyActive) {
-      makeToast('알림 신청이 완료되었습니다', 'success');
-    } else {
-      makeToast('알림 신청을 취소합니다', 'success');
-    }
-    setNotifyActive((prev) => !prev);
-  };
+    const handleNotifyToggle = useCallback(() => {
+      if (!notifyActive) {
+        makeToast('알림 신청이 완료되었습니다', 'success');
+      } else {
+        makeToast('알림 신청을 취소합니다', 'success');
+      }
+      setNotifyActive((prev) => !prev);
+    }, [notifyActive]);
 
-  return (
-    <div
-      className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
-        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px] relative`}
-      style={{ cursor: 'default' }}
-    >
-      <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden relative`}>
-        <DeviceImage
-          url={imageUrl ?? ''}
-          alt={deviceName ?? ''}
-          className={`w-full h-full object-cover ${sz.imgRadius}`}
-        />
-        {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
-        {isSoldOut && (
-          <>
-            <div
-              className={`absolute inset-0 z-10 backdrop-blur-[8px] transition-colors duration-200 ${
-                notifyActive ? 'bg-[var(--main-5)]/60' : 'bg-white/40'
-              }`}
-            />
-            <button
-              type="button"
-              className="absolute inset-0 z-20 flex flex-col items-center justify-center w-full h-full focus:outline-none"
-              onClick={handleNotifyToggle}
-              tabIndex={0}
-            >
-              <BellRing
-                size={40}
-                className={`mb-2 transition-colors duration-200 ${
-                  notifyActive
-                    ? 'text-white fill-white'
-                    : 'text-[var(--main-5)] fill-[var(--main-5)]'
+    const handleDecrement = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (id !== undefined) onCountChange(id, Math.max(0, count - 1), remainCount ?? 0);
+      },
+      [id, count, onCountChange, remainCount],
+    );
+
+    const handleIncrement = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (id !== undefined && canIncrement) onCountChange(id, count + 1, remainCount ?? 0);
+      },
+      [id, count, onCountChange, remainCount, canIncrement],
+    );
+
+    return (
+      <div
+        className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
+          ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px] relative`}
+        style={{ cursor: 'default' }}
+      >
+        <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden relative`}>
+          <DeviceImage
+            url={imageUrl ?? ''}
+            alt={deviceName ?? ''}
+            className={`w-full h-full object-cover ${sz.imgRadius}`}
+          />
+          {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
+          {isSoldOut && (
+            <>
+              <div
+                className={`absolute inset-0 z-10 backdrop-blur-[8px] transition-colors duration-200 ${
+                  notifyActive ? 'bg-[var(--main-5)]/60' : 'bg-white/40'
                 }`}
               />
-              <span
-                className={`font-title-semibold text-lg transition-colors duration-200 ${
-                  notifyActive ? 'text-white' : 'text-[var(--main-5)]'
-                }`}
+              <button
+                type="button"
+                className="absolute inset-0 z-20 flex flex-col items-center justify-center w-full h-full focus:outline-none"
+                onClick={handleNotifyToggle}
+                tabIndex={0}
               >
-                {notifyActive ? '알림 취소' : '재입고 알림 신청'}
-              </span>
-            </button>
-          </>
-        )}
-      </div>
-      {/* 정보 영역 */}
-      <div className="flex flex-col px-4 py-3 flex-1">
-        <div className="flex items-center justify-between w-full mb-1">
-          <span className="text-black">
-            <span className="font-label-regular">매일 </span>
-            <span className="font-label-semibold">{dataCapacity}GB</span>
-          </span>
-          <span className="font-label-regular text-right text-[var(--main-5)]">
-            남은 공유기 <span className="font-label-semibold">{remainCount}대</span>
-          </span>
+                <BellRing
+                  size={40}
+                  className={`mb-2 transition-colors duration-200 ${
+                    notifyActive
+                      ? 'text-white fill-white'
+                      : 'text-[var(--main-5)] fill-[var(--main-5)]'
+                  }`}
+                />
+                <span
+                  className={`font-title-semibold text-lg transition-colors duration-200 ${
+                    notifyActive ? 'text-white' : 'text-[var(--main-5)]'
+                  }`}
+                >
+                  {notifyActive ? '알림 취소' : '재입고 알림 신청'}
+                </span>
+              </button>
+            </>
+          )}
         </div>
-        <div className="font-label-semibold text-black mb-1">{deviceName}</div>
-        {/* 가격 + 수량조절 한 줄에 */}
-        <div className="flex items-center justify-between mb-2">
-          <div className="font-label-semibold text-[var(--main-5)]">
-            {typeof price === 'number' ? `${price.toLocaleString()}원` : '-'}
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
-              onClick={(e) => {
-                e.stopPropagation();
-                onCountChange(Math.max(0, count - 1));
-              }}
-              type="button"
-              disabled={count <= 0}
-            >
-              –
-            </button>
-            <span
-              className={`font-label-semibold w-6 text-center ${count > 0 ? 'text-[var(--main-5)]' : 'text-black'}`}
-            >
-              {count}
+        {/* 정보 영역 */}
+        <div className="flex flex-col px-4 py-3 flex-1">
+          <div className="flex items-center justify-between w-full mb-1">
+            <span className="text-black">
+              <span className="font-label-regular">매일 </span>
+              <span className="font-label-semibold">{dataCapacity}GB</span>
             </span>
-            <button
-              className={`w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center ${!canIncrement ? 'opacity-50 cursor-not-allowed' : ''}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onCountChange(count + 1);
-              }}
-              type="button"
-              disabled={!canIncrement}
-            >
-              +
-            </button>
+            <span className="font-label-regular text-right text-[var(--main-5)]">
+              남은 공유기 <span className="font-label-semibold">{remainCount}대</span>
+            </span>
+          </div>
+          <div className="font-label-semibold text-black mb-1">{deviceName}</div>
+          {/* 가격 + 수량조절 한 줄에 */}
+          <div className="flex items-center justify-between mb-2">
+            <div className="font-label-semibold text-[var(--main-5)]">
+              {typeof price === 'number' ? `${price.toLocaleString()}원` : '-'}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
+                onClick={handleDecrement}
+                type="button"
+                disabled={count <= 0}
+              >
+                –
+              </button>
+              <span
+                className={`font-label-semibold w-6 text-center ${count > 0 ? 'text-[var(--main-5)]' : 'text-black'}`}
+              >
+                {count}
+              </span>
+              <button
+                className={`w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center ${!canIncrement ? 'opacity-50 cursor-not-allowed' : ''}`}
+                onClick={handleIncrement}
+                type="button"
+                disabled={!canIncrement}
+              >
+                +
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);
+
+ReservationDeviceCard.displayName = 'ReservationDeviceCard';
+
+export default ReservationDeviceCard;

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -1,3 +1,5 @@
+import { BellRing } from 'lucide-react';
+
 import DeviceImage from '@/pages/rental/map/ui/DeviceImage';
 
 interface ReservationDeviceCardProps {
@@ -33,18 +35,31 @@ export default function ReservationDeviceCard({
   const sz = CARD_SIZE;
   const { deviceName, imageUrl, dataCapacity, price, remainCount } = device;
   const canIncrement = count < (max ?? 99);
+  const isSoldOut = (remainCount ?? 0) === 0;
   return (
     <div
       className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
-        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px]`}
+        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px] relative`}
       style={{ cursor: 'default' }}
     >
-      <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden`}>
+      <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden relative`}>
         <DeviceImage
           url={imageUrl ?? ''}
           alt={deviceName ?? ''}
           className={`w-full h-full object-cover ${sz.imgRadius}`}
         />
+        {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
+        {isSoldOut && (
+          <>
+            <div className="absolute inset-0 z-10 backdrop-blur-[8px] bg-white/40" />
+            <div className="absolute inset-0 z-20 flex flex-col items-center justify-center">
+              <BellRing size={40} className="text-[var(--main-5)] mb-2 fill-[var(--main-5)]" />
+              <span className="font-title-semibold text-[var(--main-5)] text-lg">
+                재입고 알림 신청
+              </span>
+            </div>
+          </>
+        )}
       </div>
       {/* 정보 영역 */}
       <div className="flex flex-col px-4 py-3 flex-1">

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -4,7 +4,6 @@ import { BellRing } from 'lucide-react';
 
 import DeviceImage from '@/pages/rental/map/ui/DeviceImage';
 import { makeToast } from '@/shared/lib/makeToast';
-import { Toaster } from '@/shared/ui/Toaster/Toaster';
 
 interface ReservationDeviceCardProps {
   device: {
@@ -43,113 +42,107 @@ export default function ReservationDeviceCard({
   const [notifyActive, setNotifyActive] = React.useState(false);
 
   const handleNotifyToggle = () => {
-    setNotifyActive((prev) => {
-      const next = !prev;
-      if (next) {
-        makeToast('알림 신청이 완료되었습니다', 'success');
-      } else {
-        makeToast('알림 신청을 취소합니다', 'success');
-      }
-      return next;
-    });
+    if (!notifyActive) {
+      makeToast('알림 신청이 완료되었습니다', 'success');
+    } else {
+      makeToast('알림 신청을 취소합니다', 'success');
+    }
+    setNotifyActive((prev) => !prev);
   };
 
   return (
-    <>
-      <Toaster />
-      <div
-        className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
-          ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px] relative`}
-        style={{ cursor: 'default' }}
-      >
-        <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden relative`}>
-          <DeviceImage
-            url={imageUrl ?? ''}
-            alt={deviceName ?? ''}
-            className={`w-full h-full object-cover ${sz.imgRadius}`}
-          />
-          {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
-          {isSoldOut && (
-            <>
-              <div
-                className={`absolute inset-0 z-10 backdrop-blur-[8px] transition-colors duration-200 ${
-                  notifyActive ? 'bg-[var(--main-5)]/60' : 'bg-white/40'
+    <div
+      className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
+        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px] relative`}
+      style={{ cursor: 'default' }}
+    >
+      <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden relative`}>
+        <DeviceImage
+          url={imageUrl ?? ''}
+          alt={deviceName ?? ''}
+          className={`w-full h-full object-cover ${sz.imgRadius}`}
+        />
+        {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
+        {isSoldOut && (
+          <>
+            <div
+              className={`absolute inset-0 z-10 backdrop-blur-[8px] transition-colors duration-200 ${
+                notifyActive ? 'bg-[var(--main-5)]/60' : 'bg-white/40'
+              }`}
+            />
+            <button
+              type="button"
+              className="absolute inset-0 z-20 flex flex-col items-center justify-center w-full h-full focus:outline-none"
+              onClick={handleNotifyToggle}
+              tabIndex={0}
+            >
+              <BellRing
+                size={40}
+                className={`mb-2 transition-colors duration-200 ${
+                  notifyActive
+                    ? 'text-white fill-white'
+                    : 'text-[var(--main-5)] fill-[var(--main-5)]'
                 }`}
               />
-              <button
-                type="button"
-                className="absolute inset-0 z-20 flex flex-col items-center justify-center w-full h-full focus:outline-none"
-                onClick={handleNotifyToggle}
-                tabIndex={0}
-              >
-                <BellRing
-                  size={40}
-                  className={`mb-2 transition-colors duration-200 ${
-                    notifyActive
-                      ? 'text-white fill-white'
-                      : 'text-[var(--main-5)] fill-[var(--main-5)]'
-                  }`}
-                />
-                <span
-                  className={`font-title-semibold text-lg transition-colors duration-200 ${
-                    notifyActive ? 'text-white' : 'text-[var(--main-5)]'
-                  }`}
-                >
-                  {notifyActive ? '알림 취소' : '재입고 알림 신청'}
-                </span>
-              </button>
-            </>
-          )}
-        </div>
-        {/* 정보 영역 */}
-        <div className="flex flex-col px-4 py-3 flex-1">
-          <div className="flex items-center justify-between w-full mb-1">
-            <span className="text-black">
-              <span className="font-label-regular">매일 </span>
-              <span className="font-label-semibold">{dataCapacity}GB</span>
-            </span>
-            <span className="font-label-regular text-right text-[var(--main-5)]">
-              남은 공유기 <span className="font-label-semibold">{remainCount}대</span>
-            </span>
-          </div>
-          <div className="font-label-semibold text-black mb-1">{deviceName}</div>
-          {/* 가격 + 수량조절 한 줄에 */}
-          <div className="flex items-center justify-between mb-2">
-            <div className="font-label-semibold text-[var(--main-5)]">
-              {typeof price === 'number' ? `${price.toLocaleString()}원` : '-'}
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCountChange(Math.max(0, count - 1));
-                }}
-                type="button"
-                disabled={count <= 0}
-              >
-                –
-              </button>
               <span
-                className={`font-label-semibold w-6 text-center ${count > 0 ? 'text-[var(--main-5)]' : 'text-black'}`}
+                className={`font-title-semibold text-lg transition-colors duration-200 ${
+                  notifyActive ? 'text-white' : 'text-[var(--main-5)]'
+                }`}
               >
-                {count}
+                {notifyActive ? '알림 취소' : '재입고 알림 신청'}
               </span>
-              <button
-                className={`w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center ${!canIncrement ? 'opacity-50 cursor-not-allowed' : ''}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCountChange(count + 1);
-                }}
-                type="button"
-                disabled={!canIncrement}
-              >
-                +
-              </button>
-            </div>
+            </button>
+          </>
+        )}
+      </div>
+      {/* 정보 영역 */}
+      <div className="flex flex-col px-4 py-3 flex-1">
+        <div className="flex items-center justify-between w-full mb-1">
+          <span className="text-black">
+            <span className="font-label-regular">매일 </span>
+            <span className="font-label-semibold">{dataCapacity}GB</span>
+          </span>
+          <span className="font-label-regular text-right text-[var(--main-5)]">
+            남은 공유기 <span className="font-label-semibold">{remainCount}대</span>
+          </span>
+        </div>
+        <div className="font-label-semibold text-black mb-1">{deviceName}</div>
+        {/* 가격 + 수량조절 한 줄에 */}
+        <div className="flex items-center justify-between mb-2">
+          <div className="font-label-semibold text-[var(--main-5)]">
+            {typeof price === 'number' ? `${price.toLocaleString()}원` : '-'}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCountChange(Math.max(0, count - 1));
+              }}
+              type="button"
+              disabled={count <= 0}
+            >
+              –
+            </button>
+            <span
+              className={`font-label-semibold w-6 text-center ${count > 0 ? 'text-[var(--main-5)]' : 'text-black'}`}
+            >
+              {count}
+            </span>
+            <button
+              className={`w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center ${!canIncrement ? 'opacity-50 cursor-not-allowed' : ''}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCountChange(count + 1);
+              }}
+              type="button"
+              disabled={!canIncrement}
+            >
+              +
+            </button>
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -1,31 +1,41 @@
 import React from 'react';
 
-interface DeviceCardProps {
+interface ReservationDeviceCardProps {
   name: string;
   price: string;
   image?: string;
+  selected?: boolean;
+  onClick?: () => void;
 }
 
-export const DeviceCard: React.FC<DeviceCardProps> = ({ name, price, image }) => {
-  return (
-    <div className="min-w-[180px] max-w-[180px] h-[180px] flex flex-col items-start">
-      <div
-        className="w-full h-[140px] rounded-[28px] mb-2 flex items-center justify-center overflow-hidden"
-        style={{
-          backgroundImage:
-            'linear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%),\nlinear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%)',
-          backgroundSize: '32px 32px',
-          backgroundPosition: '0 0, 16px 16px',
-        }}
-      >
-        {image ? <img src={image} alt={name} className="object-contain w-full h-full" /> : null}
-      </div>
-      <div className="w-full text-left">
-        <div className="font-bold text-lg leading-tight">{name}</div>
-        <div className="text-base mt-1">{price}</div>
-      </div>
+const ReservationDeviceCard: React.FC<ReservationDeviceCardProps> = ({
+  name,
+  price,
+  image,
+  selected,
+  onClick,
+}) => (
+  <div
+    className={`min-w-[180px] max-w-[180px] h-[180px] flex flex-col items-start cursor-pointer
+      ${selected ? 'border-2 border-[var(--main-5)]' : 'border border-transparent'}`}
+    onClick={onClick}
+  >
+    <div
+      className="w-full h-[140px] rounded-[28px] mb-2 flex items-center justify-center overflow-hidden"
+      style={{
+        backgroundImage:
+          'linear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%),\nlinear-gradient(45deg, #f3f3f3 25%, transparent 25%, transparent 75%, #f3f3f3 75%)',
+        backgroundSize: '32px 32px',
+        backgroundPosition: '0 0, 16px 16px',
+      }}
+    >
+      {image ? <img src={image} alt={name} className="object-contain w-full h-full" /> : null}
     </div>
-  );
-};
+    <div className="w-full text-left">
+      <div className="font-title-semibold text-black">{name}</div>
+      <div className="font-label-regular text-black">{price}</div>
+    </div>
+  </div>
+);
 
-export default DeviceCard;
+export default ReservationDeviceCard;

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { BellRing } from 'lucide-react';
 
 import DeviceImage from '@/pages/rental/map/ui/DeviceImage';
+import { makeToast } from '@/shared/lib/makeToast';
+import { Toaster } from '@/shared/ui/Toaster/Toaster';
 
 interface ReservationDeviceCardProps {
   device: {
@@ -23,8 +25,8 @@ const CARD_SIZE = {
   w: 'w-[270px]',
   h: 'h-[230px]',
   img: 'h-[135px]',
-  radius: 'rounded-[20px]', // 카드 전체 radius
-  imgRadius: 'rounded-t-[20px]', // 이미지 상단 radius 동일하게
+  radius: 'rounded-[20px]',
+  imgRadius: 'rounded-t-[20px]',
 };
 
 export default function ReservationDeviceCard({
@@ -40,99 +42,114 @@ export default function ReservationDeviceCard({
   const isSoldOut = (remainCount ?? 0) === 0;
   const [notifyActive, setNotifyActive] = React.useState(false);
 
+  const handleNotifyToggle = () => {
+    setNotifyActive((prev) => {
+      const next = !prev;
+      if (next) {
+        makeToast('알림 신청이 완료되었습니다', 'success');
+      } else {
+        makeToast('알림 신청을 취소합니다', 'success');
+      }
+      return next;
+    });
+  };
+
   return (
-    <div
-      className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
-        ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px] relative`}
-      style={{ cursor: 'default' }}
-    >
-      <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden relative`}>
-        <DeviceImage
-          url={imageUrl ?? ''}
-          alt={deviceName ?? ''}
-          className={`w-full h-full object-cover ${sz.imgRadius}`}
-        />
-        {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
-        {isSoldOut && (
-          <>
-            <div
-              className={`absolute inset-0 z-10 backdrop-blur-[8px] transition-colors duration-200 ${
-                notifyActive ? 'bg-[var(--main-5)]/60' : 'bg-white/40'
-              }`}
-            />
-            <button
-              type="button"
-              className="absolute inset-0 z-20 flex flex-col items-center justify-center w-full h-full focus:outline-none"
-              onClick={() => setNotifyActive((prev) => !prev)}
-              tabIndex={0}
-            >
-              <BellRing
-                size={40}
-                className={`mb-2 transition-colors duration-200 ${
-                  notifyActive
-                    ? 'text-white fill-white'
-                    : 'text-[var(--main-5)] fill-[var(--main-5)]'
+    <>
+      <Toaster />
+      <div
+        className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
+          ${selected ? 'border-[var(--main-5)] border-2' : 'border border-[var(--gray-light)]'} flex-shrink-0 min-w-[270px] relative`}
+        style={{ cursor: 'default' }}
+      >
+        <div className={`w-full ${sz.img} ${sz.imgRadius} rounded-b-none overflow-hidden relative`}>
+          <DeviceImage
+            url={imageUrl ?? ''}
+            alt={deviceName ?? ''}
+            className={`w-full h-full object-cover ${sz.imgRadius}`}
+          />
+          {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
+          {isSoldOut && (
+            <>
+              <div
+                className={`absolute inset-0 z-10 backdrop-blur-[8px] transition-colors duration-200 ${
+                  notifyActive ? 'bg-[var(--main-5)]/60' : 'bg-white/40'
                 }`}
               />
-              <span
-                className={`font-title-semibold text-lg transition-colors duration-200 ${
-                  notifyActive ? 'text-white' : 'text-[var(--main-5)]'
-                }`}
+              <button
+                type="button"
+                className="absolute inset-0 z-20 flex flex-col items-center justify-center w-full h-full focus:outline-none"
+                onClick={handleNotifyToggle}
+                tabIndex={0}
               >
-                {notifyActive ? '알림 취소' : '재입고 알림 신청'}
-              </span>
-            </button>
-          </>
-        )}
-      </div>
-      {/* 정보 영역 */}
-      <div className="flex flex-col px-4 py-3 flex-1">
-        <div className="flex items-center justify-between w-full mb-1">
-          <span className="text-black">
-            <span className="font-label-regular">매일 </span>
-            <span className="font-label-semibold">{dataCapacity}GB</span>
-          </span>
-          <span className="font-label-regular text-right text-[var(--main-5)]">
-            남은 공유기 <span className="font-label-semibold">{remainCount}대</span>
-          </span>
+                <BellRing
+                  size={40}
+                  className={`mb-2 transition-colors duration-200 ${
+                    notifyActive
+                      ? 'text-white fill-white'
+                      : 'text-[var(--main-5)] fill-[var(--main-5)]'
+                  }`}
+                />
+                <span
+                  className={`font-title-semibold text-lg transition-colors duration-200 ${
+                    notifyActive ? 'text-white' : 'text-[var(--main-5)]'
+                  }`}
+                >
+                  {notifyActive ? '알림 취소' : '재입고 알림 신청'}
+                </span>
+              </button>
+            </>
+          )}
         </div>
-        <div className="font-label-semibold text-black mb-1">{deviceName}</div>
-        {/* 가격 + 수량조절 한 줄에 */}
-        <div className="flex items-center justify-between mb-2">
-          <div className="font-label-semibold text-[var(--main-5)]">
-            {typeof price === 'number' ? `${price.toLocaleString()}원` : '-'}
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
-              onClick={(e) => {
-                e.stopPropagation();
-                onCountChange(Math.max(0, count - 1));
-              }}
-              type="button"
-              disabled={count <= 0}
-            >
-              –
-            </button>
-            <span
-              className={`font-label-semibold w-6 text-center ${count > 0 ? 'text-[var(--main-5)]' : 'text-black'}`}
-            >
-              {count}
+        {/* 정보 영역 */}
+        <div className="flex flex-col px-4 py-3 flex-1">
+          <div className="flex items-center justify-between w-full mb-1">
+            <span className="text-black">
+              <span className="font-label-regular">매일 </span>
+              <span className="font-label-semibold">{dataCapacity}GB</span>
             </span>
-            <button
-              className={`w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center ${!canIncrement ? 'opacity-50 cursor-not-allowed' : ''}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onCountChange(count + 1);
-              }}
-              type="button"
-              disabled={!canIncrement}
-            >
-              +
-            </button>
+            <span className="font-label-regular text-right text-[var(--main-5)]">
+              남은 공유기 <span className="font-label-semibold">{remainCount}대</span>
+            </span>
+          </div>
+          <div className="font-label-semibold text-black mb-1">{deviceName}</div>
+          {/* 가격 + 수량조절 한 줄에 */}
+          <div className="flex items-center justify-between mb-2">
+            <div className="font-label-semibold text-[var(--main-5)]">
+              {typeof price === 'number' ? `${price.toLocaleString()}원` : '-'}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                className="w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCountChange(Math.max(0, count - 1));
+                }}
+                type="button"
+                disabled={count <= 0}
+              >
+                –
+              </button>
+              <span
+                className={`font-label-semibold w-6 text-center ${count > 0 ? 'text-[var(--main-5)]' : 'text-black'}`}
+              >
+                {count}
+              </span>
+              <button
+                className={`w-7 h-7 rounded bg-[var(--gray-light)] text-title-semibold flex items-center justify-center ${!canIncrement ? 'opacity-50 cursor-not-allowed' : ''}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCountChange(count + 1);
+                }}
+                type="button"
+                disabled={!canIncrement}
+              >
+                +
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/pages/rental/map/ui/ReservationDeviceCard.tsx
+++ b/src/pages/rental/map/ui/ReservationDeviceCard.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { BellRing } from 'lucide-react';
 
 import DeviceImage from '@/pages/rental/map/ui/DeviceImage';
@@ -36,6 +38,8 @@ export default function ReservationDeviceCard({
   const { deviceName, imageUrl, dataCapacity, price, remainCount } = device;
   const canIncrement = count < (max ?? 99);
   const isSoldOut = (remainCount ?? 0) === 0;
+  const [notifyActive, setNotifyActive] = React.useState(false);
+
   return (
     <div
       className={`${sz.radius} bg-white ${sz.w} ${sz.h} overflow-hidden flex flex-col border transition
@@ -51,13 +55,33 @@ export default function ReservationDeviceCard({
         {/* 품절 시 블러 및 오버레이 (이미지 위에만) */}
         {isSoldOut && (
           <>
-            <div className="absolute inset-0 z-10 backdrop-blur-[8px] bg-white/40" />
-            <div className="absolute inset-0 z-20 flex flex-col items-center justify-center">
-              <BellRing size={40} className="text-[var(--main-5)] mb-2 fill-[var(--main-5)]" />
-              <span className="font-title-semibold text-[var(--main-5)] text-lg">
-                재입고 알림 신청
+            <div
+              className={`absolute inset-0 z-10 backdrop-blur-[8px] transition-colors duration-200 ${
+                notifyActive ? 'bg-[var(--main-5)]/60' : 'bg-white/40'
+              }`}
+            />
+            <button
+              type="button"
+              className="absolute inset-0 z-20 flex flex-col items-center justify-center w-full h-full focus:outline-none"
+              onClick={() => setNotifyActive((prev) => !prev)}
+              tabIndex={0}
+            >
+              <BellRing
+                size={40}
+                className={`mb-2 transition-colors duration-200 ${
+                  notifyActive
+                    ? 'text-white fill-white'
+                    : 'text-[var(--main-5)] fill-[var(--main-5)]'
+                }`}
+              />
+              <span
+                className={`font-title-semibold text-lg transition-colors duration-200 ${
+                  notifyActive ? 'text-white' : 'text-[var(--main-5)]'
+                }`}
+              >
+                {notifyActive ? '알림 취소' : '재입고 알림 신청'}
               </span>
-            </div>
+            </button>
           </>
         )}
       </div>

--- a/src/pages/rental/store/reservation/model/reservationReducer.ts
+++ b/src/pages/rental/store/reservation/model/reservationReducer.ts
@@ -1,0 +1,39 @@
+import type { DateRange } from 'react-day-picker';
+
+export interface State {
+  dateRange: DateRange | undefined;
+  selectedDeviceId: number | null;
+  agreed: boolean;
+  isSubmitting: boolean;
+}
+
+export type Action =
+  | { type: 'SET_DATE_RANGE'; payload: DateRange | undefined }
+  | { type: 'SET_SELECTED_DEVICE'; payload: number | null }
+  | { type: 'SET_AGREED'; payload: boolean }
+  | { type: 'SET_SUBMITTING'; payload: boolean }
+  | { type: 'RESET' };
+
+export const initialState: State = {
+  dateRange: undefined,
+  selectedDeviceId: null,
+  agreed: false,
+  isSubmitting: false,
+};
+
+export function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'SET_DATE_RANGE':
+      return { ...state, dateRange: action.payload };
+    case 'SET_SELECTED_DEVICE':
+      return { ...state, selectedDeviceId: action.payload };
+    case 'SET_AGREED':
+      return { ...state, agreed: action.payload };
+    case 'SET_SUBMITTING':
+      return { ...state, isSubmitting: action.payload };
+    case 'RESET':
+      return initialState;
+    default:
+      return state;
+  }
+}

--- a/src/pages/rental/store/reservation/page/CalendarSection.tsx
+++ b/src/pages/rental/store/reservation/page/CalendarSection.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { Calendar as CalendarIcon } from 'lucide-react';
+
+import { Calendar } from '@/components/ui/calendar';
+
+import type { DateRange } from 'react-day-picker';
+
+interface CalendarSectionProps {
+  dateRange: DateRange | undefined;
+  onChange: (range: DateRange | undefined) => void;
+}
+
+const CalendarSection: React.FC<CalendarSectionProps> = ({ dateRange, onChange }) => (
+  <>
+    <div className="font-body-semibold text-lg flex items-center gap-2">
+      <CalendarIcon size={20} className="text-[var(--main-5)]" />
+      날짜를 선택해 주세요
+    </div>
+    <div className="w-full">
+      <Calendar
+        mode="range"
+        selected={dateRange}
+        onSelect={onChange}
+        required
+        className="rounded-md w-full"
+      />
+    </div>
+  </>
+);
+
+export default CalendarSection;

--- a/src/pages/rental/store/reservation/page/DeviceSelectSection.tsx
+++ b/src/pages/rental/store/reservation/page/DeviceSelectSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { CircleCheck } from 'lucide-react';
 
@@ -6,9 +6,11 @@ import ReservationDeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
 
 interface Device {
   id: number;
-  name: string;
-  price: string;
-  image?: string;
+  deviceName: string;
+  imageUrl: string;
+  dataCapacity: number | string;
+  price: number;
+  remainCount: number;
 }
 
 interface DeviceSelectSectionProps {
@@ -21,25 +23,35 @@ const DeviceSelectSection: React.FC<DeviceSelectSectionProps> = ({
   devices,
   selectedDeviceId,
   onSelect,
-}) => (
-  <>
-    <div className="font-body-semibold text-lg flex items-center gap-2 mt-6">
-      <CircleCheck size={28} className="text-[var(--main-5)]" />
-      기기를 선택해 주세요
-    </div>
-    <div className="flex flex-row gap-6 overflow-x-auto pb-2 pl-1">
-      {devices.map((device) => (
-        <ReservationDeviceCard
-          key={device.id}
-          name={device.name}
-          price={device.price}
-          image={device.image}
-          selected={selectedDeviceId === device.id}
-          onClick={() => onSelect(device.id)}
-        />
-      ))}
-    </div>
-  </>
-);
+}) => {
+  const [counts, setCounts] = useState<Record<number, number>>(
+    devices.reduce((acc, d) => ({ ...acc, [d.id]: 0 }), {} as Record<number, number>),
+  );
+
+  const handleCountChange = (id: number, newCount: number) => {
+    setCounts((prev) => ({ ...prev, [id]: Math.max(0, newCount) }));
+  };
+
+  return (
+    <>
+      <div className="font-body-semibold text-lg flex items-center gap-2 mt-6">
+        <CircleCheck size={28} className="text-[var(--main-5)]" />
+        기기를 선택해 주세요
+      </div>
+      <div className="flex flex-row gap-6 overflow-x-auto pb-2 pl-1">
+        {devices.map((device) => (
+          <ReservationDeviceCard
+            key={device.id}
+            device={device}
+            count={counts[device.id] ?? 0}
+            onCountChange={(newCount) => handleCountChange(device.id, newCount)}
+            selected={selectedDeviceId === device.id}
+            onClick={() => onSelect(device.id)}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
 
 export default DeviceSelectSection;

--- a/src/pages/rental/store/reservation/page/DeviceSelectSection.tsx
+++ b/src/pages/rental/store/reservation/page/DeviceSelectSection.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { CircleCheck } from 'lucide-react';
+
+import ReservationDeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
+
+interface Device {
+  id: number;
+  name: string;
+  price: string;
+  image?: string;
+}
+
+interface DeviceSelectSectionProps {
+  devices: Device[];
+  selectedDeviceId: number | null;
+  onSelect: (id: number) => void;
+}
+
+const DeviceSelectSection: React.FC<DeviceSelectSectionProps> = ({
+  devices,
+  selectedDeviceId,
+  onSelect,
+}) => (
+  <>
+    <div className="font-body-semibold text-lg flex items-center gap-2 mt-6">
+      <CircleCheck size={28} className="text-[var(--main-5)]" />
+      기기를 선택해 주세요
+    </div>
+    <div className="flex flex-row gap-6 overflow-x-auto pb-2 pl-1">
+      {devices.map((device) => (
+        <ReservationDeviceCard
+          key={device.id}
+          name={device.name}
+          price={device.price}
+          image={device.image}
+          selected={selectedDeviceId === device.id}
+          onClick={() => onSelect(device.id)}
+        />
+      ))}
+    </div>
+  </>
+);
+
+export default DeviceSelectSection;

--- a/src/pages/rental/store/reservation/page/DeviceSelectSection.tsx
+++ b/src/pages/rental/store/reservation/page/DeviceSelectSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { CircleCheck } from 'lucide-react';
 
@@ -24,12 +24,18 @@ const DeviceSelectSection: React.FC<DeviceSelectSectionProps> = ({
   selectedDeviceId,
   onSelect,
 }) => {
-  const [counts, setCounts] = useState<Record<number, number>>(
+  const [counts, setCounts] = React.useState<Record<number, number>>(
     devices.reduce((acc, d) => ({ ...acc, [d.id]: 0 }), {} as Record<number, number>),
   );
 
-  const handleCountChange = (id: number, newCount: number) => {
-    setCounts((prev) => ({ ...prev, [id]: Math.max(0, newCount) }));
+  const handleCountChange = (id: number, newCount: number, remainCount: number) => {
+    const safeCount = Math.max(0, Math.min(newCount, remainCount));
+    setCounts((prev) => ({ ...prev, [id]: safeCount }));
+    if (safeCount > 0) {
+      onSelect(id);
+    } else if (selectedDeviceId === id) {
+      onSelect(-1);
+    }
   };
 
   return (
@@ -44,9 +50,9 @@ const DeviceSelectSection: React.FC<DeviceSelectSectionProps> = ({
             key={device.id}
             device={device}
             count={counts[device.id] ?? 0}
-            onCountChange={(newCount) => handleCountChange(device.id, newCount)}
+            onCountChange={(newCount) => handleCountChange(device.id, newCount, device.remainCount)}
             selected={selectedDeviceId === device.id}
-            onClick={() => onSelect(device.id)}
+            max={device.remainCount}
           />
         ))}
       </div>

--- a/src/pages/rental/store/reservation/page/NoticeSection.tsx
+++ b/src/pages/rental/store/reservation/page/NoticeSection.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+interface NoticeSectionProps {
+  agreed: boolean;
+  onToggleAgreed: () => void;
+}
+
+const NoticeSection: React.FC<NoticeSectionProps> = ({ agreed, onToggleAgreed }) => (
+  <div className="w-full bg-white rounded-xl px-2 pt-4 pb-2 text-black flex flex-col items-center">
+    <div className="font-body-semibold mt-5 mb-10 text-center">
+      아래 주의 사항을 꼭 읽어보시고
+      <br />
+      약관 내용에 동의해 주세요
+    </div>
+    <ul className="list-disc pl-5 space-y-1 font-label-regular w-full">
+      <li>
+        기기는 반드시{' '}
+        <span className="text-[var(--main-5)] font-label-semibold">
+          대여 신청 당일 대리점 영업시간 내에 수령
+        </span>
+        하셔야 합니다.
+      </li>
+      <li>
+        대여 신청 당일에 수령하지 않을 시 해당 기기에 대한 예약 내역은{' '}
+        <span className="text-[var(--main-5)] font-semibold">자동 취소</span>되오니 신중히 예약
+        부탁드립니다.
+      </li>
+      <li>
+        반납은{' '}
+        <span className="text-[var(--main-5)] font-label-semibold">
+          대여 종료일 당일 대리점 영업시간 내에
+        </span>{' '}
+        하셔야 합니다.
+      </li>
+      <li>
+        기기 미반납 시{' '}
+        <span className="text-[var(--main-5)] font-label-semibold">연체료 및 기기 손해배상금</span>
+        이 발생하며, 법적 조치를 취할 수 있습니다.
+      </li>
+      <li>
+        단말기에 대한 손실 및 파손 발생 시,{' '}
+        <span className="text-[var(--main-5)] font-label-semibold">추가 비용</span>이 발생할 수
+        있습니다.
+      </li>
+      <li>
+        분실/파손/기기 반환지연이 반복적으로 발생되는 경우, 고객은{' '}
+        <span className="text-[var(--main-5)] font-label-semibold">즉시 대여이용이 제한</span>될 수
+        있습니다.
+      </li>
+      <li>
+        단말기 대리점으로 연락하지 않고 미반납/미수령 시, 대리점은 이에 대한{' '}
+        <span className="text-[var(--main-5)] font-label-semibold">책임이 없습니다</span>.
+      </li>
+    </ul>
+    <div className="my-10 text-center font-label-medium flex items-center justify-center gap-2">
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={agreed}
+        onClick={onToggleAgreed}
+        className="w-6 h-6 rounded border-2 border-[var(--main-5)] flex items-center justify-center mr-2 focus:outline-none focus:ring-2 focus:ring-[var(--main-5)] bg-white"
+        style={{ minWidth: 24 }}
+      >
+        {agreed && (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4 8.5L7 11.5L12 5.5"
+              stroke="var(--main-5)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+      </button>
+      위 사항에 동의하십니까?
+    </div>
+  </div>
+);
+
+export default NoticeSection;

--- a/src/pages/rental/store/reservation/page/ReceiptSection.tsx
+++ b/src/pages/rental/store/reservation/page/ReceiptSection.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import Image from 'next/image';
+
+import DeviceReceiptItem from '@/pages/rental/store/reservation/ui/DeviceReciptItem';
+import { ICONS } from '@/shared/config/iconPath';
+import { RegisterButton } from '@/shared/ui/RegisterButton/RegisterButton';
+
+interface ReceiptSectionProps {
+  periodDate: string;
+  periodDays: string;
+  devices: { name: string; price: string; count: number }[];
+  onPay?: () => void;
+  onClose?: () => void;
+}
+
+const ReceiptSection: React.FC<ReceiptSectionProps> = ({
+  periodDate,
+  periodDays,
+  devices,
+  onPay,
+  onClose,
+}) => {
+  const getNumber = (str: string) => Number(str.replace(/[^0-9]/g, ''));
+  const total =
+    devices.reduce((sum, d) => sum + getNumber(d.price) * d.count, 0).toLocaleString() + '원';
+
+  return (
+    <div className="flex flex-col items-center justify-center py-10">
+      <div className="bg-white rounded-t-2xl shadow-lg w-[320px] mx-auto p-6 relative flex flex-col items-center">
+        {/* 상단: 로고, 날짜, 닫기 */}
+        <div className="flex w-full items-center justify-between mb-4 relative">
+          <Image
+            src={ICONS.LOGO.BADATA}
+            alt="badata logo"
+            width={80}
+            height={24}
+            className="object-contain"
+          />
+          <div className="text-xs text-gray-400 text-right">
+            <div>{periodDate}</div>
+            <div>{periodDays}</div>
+          </div>
+          {onClose && (
+            <button
+              className="absolute top-0 right-0 text-gray-400 hover:text-black text-2xl"
+              onClick={onClose}
+              aria-label="Close"
+              style={{ transform: 'translate(120%, -20%)' }}
+            >
+              ×
+            </button>
+          )}
+        </div>
+        {/* 디바이스 리스트 */}
+        <div className="w-full flex flex-col gap-2 mb-2">
+          {devices.map((d, i) => (
+            <DeviceReceiptItem key={i} name={d.name} price={d.price} count={d.count} />
+          ))}
+        </div>
+        <div className="border-t border-dashed border-gray-200 my-3 w-full" />
+        {/* Total */}
+        <div className="w-full flex justify-between items-center mb-1">
+          <span className="font-bold text-base text-black">Total</span>
+          <span className="font-bold text-2xl text-black">{total}</span>
+        </div>
+      </div>
+      {/* 구불구불한 하단 SVG */}
+      <svg
+        width="320"
+        height="20"
+        viewBox="0 0 320 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="block"
+        style={{ marginTop: '-1px' }}
+      >
+        <rect width="320" height="10" fill="white" />
+        {Array.from({ length: 16 }).map((_, i) => (
+          <circle key={i} cx={10 + i * 20} cy={10} r={10} fill="white" stroke="none" />
+        ))}
+      </svg>
+      <RegisterButton
+        className="mt-8 w-[180px] h-[54px] rounded-xl bg-[var(--main-5)] text-white font-bold text-xl shadow-md hover:bg-[var(--main-4)] transition"
+        size="lg"
+        isFormValid={true}
+        onClick={onPay}
+      >
+        결제
+      </RegisterButton>
+    </div>
+  );
+};
+
+export default ReceiptSection;

--- a/src/pages/rental/store/reservation/page/ReceiptSection.tsx
+++ b/src/pages/rental/store/reservation/page/ReceiptSection.tsx
@@ -6,13 +6,21 @@ import DeviceReceiptItem from '@/pages/rental/store/reservation/ui/DeviceReciptI
 import { ICONS } from '@/shared/config/iconPath';
 import { RegisterButton } from '@/shared/ui/RegisterButton/RegisterButton';
 
+interface DeviceItem {
+  name: string;
+  price: string;
+  count: number;
+}
+
 interface ReceiptSectionProps {
   periodDate: string;
   periodDays: string;
-  devices: { name: string; price: string; count: number }[];
+  devices: DeviceItem[];
   onPay?: () => void;
   onClose?: () => void;
 }
+
+const getNumber = (str: string) => Number(str.replace(/[^0-9]/g, ''));
 
 const ReceiptSection: React.FC<ReceiptSectionProps> = ({
   periodDate,
@@ -21,37 +29,38 @@ const ReceiptSection: React.FC<ReceiptSectionProps> = ({
   onPay,
   onClose,
 }) => {
-  const getNumber = (str: string) => Number(str.replace(/[^0-9]/g, ''));
   const total =
     devices.reduce((sum, d) => sum + getNumber(d.price) * d.count, 0).toLocaleString() + '원';
 
   return (
     <div className="flex flex-col items-center justify-center py-10">
       <div className="bg-white rounded-t-2xl shadow-lg w-[320px] mx-auto p-6 relative flex flex-col items-center">
-        {/* 상단: 로고, 날짜, 닫기 */}
-        <div className="flex w-full items-center justify-between mb-4 relative">
-          <Image
-            src={ICONS.LOGO.BADATA}
-            alt="badata logo"
-            width={80}
-            height={24}
-            className="object-contain"
-          />
-          <div className="text-xs text-gray-400 text-right">
-            <div>{periodDate}</div>
-            <div>{periodDays}</div>
-          </div>
-          {onClose && (
-            <button
-              className="absolute top-0 right-0 text-gray-400 hover:text-black text-2xl"
-              onClick={onClose}
-              aria-label="Close"
-              style={{ transform: 'translate(120%, -20%)' }}
-            >
-              ×
-            </button>
-          )}
+        {/* X 버튼: 카드 상단 우측 */}
+        {onClose && (
+          <button
+            className="absolute top-3 right-5 text-[var(--gray-dark)] hover:text-black font-title-semibold"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        )}
+        {/* 바다 로고: 카드 상단 좌측 absolute */}
+        <Image
+          src={ICONS.LOGO.BADATA}
+          alt="badata logo"
+          width={60}
+          height={18}
+          className="object-contain absolute top-3 left-5"
+        />
+        {/* period(날짜) row, X와의 간격 mt-8 */}
+        <div className="w-full flex flex-col items-start mt-18">
+          <span className="font-body-semibold text-black leading-tight">{periodDate}</span>
+          <span className="font-label-regular text-[var(--gray-dark)] leading-tight">
+            {periodDays}
+          </span>
         </div>
+        <div className="border-t border-dashed border- my-3 w-full" />
         {/* 디바이스 리스트 */}
         <div className="w-full flex flex-col gap-2 mb-2">
           {devices.map((d, i) => (
@@ -61,11 +70,11 @@ const ReceiptSection: React.FC<ReceiptSectionProps> = ({
         <div className="border-t border-dashed border-gray-200 my-3 w-full" />
         {/* Total */}
         <div className="w-full flex justify-between items-center mb-1">
-          <span className="font-bold text-base text-black">Total</span>
-          <span className="font-bold text-2xl text-black">{total}</span>
+          <span className="font-title-semibold text-black">Total</span>
+          <span className="font-title-semibold text-black">{total}</span>
         </div>
       </div>
-      {/* 구불구불한 하단 SVG */}
+      {/* 구불구불 SVG */}
       <svg
         width="320"
         height="20"
@@ -81,7 +90,7 @@ const ReceiptSection: React.FC<ReceiptSectionProps> = ({
         ))}
       </svg>
       <RegisterButton
-        className="mt-8 w-[180px] h-[54px] rounded-xl bg-[var(--main-5)] text-white font-bold text-xl shadow-md hover:bg-[var(--main-4)] transition"
+        className="mt-8 w-[180px] h-[54px] rounded-xl bg-[var(--main-5)] text-white font-title-semibold shadow-md hover:bg-[var(--main-4)] transition"
         size="lg"
         isFormValid={true}
         onClick={onPay}

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -8,6 +8,7 @@ import { Calendar as CalendarIcon, CircleCheck } from 'lucide-react';
 
 import { Calendar } from '@/components/ui/calendar';
 import ReservationDeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
+import { makeToast } from '@/shared/lib/makeToast';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { FlatTab } from '@/shared/ui/FlatTab/FlatTab';
 import { Header_Detail } from '@/shared/ui/Header_Detail';
@@ -42,6 +43,14 @@ const ReservationPage = () => {
   const isDateSelected = !!(selectedRange && selectedRange.from && selectedRange.to);
   const isDeviceSelected = !!selectedDeviceId;
   const isFormValid = isDateSelected && isDeviceSelected && agreed;
+
+  // 오늘 이후 날짜인지 검사
+  const isDateFuture = (() => {
+    if (!selectedRange || !selectedRange.from || !selectedRange.to) return true;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return selectedRange.from >= today && selectedRange.to >= today;
+  })();
 
   return (
     <BaseLayout
@@ -170,6 +179,11 @@ const ReservationPage = () => {
               isFormValid={isFormValid}
               onClick={(e) => {
                 if (!isFormValid) {
+                  e.preventDefault();
+                  return;
+                }
+                if (!isDateFuture) {
+                  makeToast('날짜를 다시 선택해주세요', 'warning');
                   e.preventDefault();
                 }
               }}

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -7,13 +7,13 @@ import { useParams } from 'next/navigation';
 import { Calendar as CalendarIcon, CircleCheck } from 'lucide-react';
 
 import { Calendar } from '@/components/ui/calendar';
+import ReservationDeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { FlatTab } from '@/shared/ui/FlatTab/FlatTab';
 import { Header_Detail } from '@/shared/ui/Header_Detail';
 import { RegisterButton } from '@/shared/ui/RegisterButton/RegisterButton';
 
 import type { DateRange } from 'react-day-picker';
-import ReservationDeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
 
 // 예시 mock 데이터
 const mockDevices = [
@@ -37,6 +37,11 @@ const ReservationPage = () => {
     { label: '상세정보', value: '상세정보' },
     { label: '리뷰', value: '리뷰' },
   ];
+
+  // 날짜, 기기, 동의 체크 모두 선택되어야 예약하기 버튼 활성화
+  const isDateSelected = !!(selectedRange && selectedRange.from && selectedRange.to);
+  const isDeviceSelected = !!selectedDeviceId;
+  const isFormValid = isDateSelected && isDeviceSelected && agreed;
 
   return (
     <BaseLayout
@@ -160,9 +165,14 @@ const ReservationPage = () => {
               </div>
             </div>
             <RegisterButton
-              className={`w-full mb-10 ${agreed ? 'bg-[var(--main-5)] text-white' : 'bg-[var(--gray)] text-white'}`}
+              className={`w-full mb-10 ${isFormValid ? 'bg-[var(--main-5)] text-white' : 'bg-[var(--gray)] text-white'}`}
               size="lg"
-              isFormValid={agreed}
+              isFormValid={isFormValid}
+              onClick={(e) => {
+                if (!isFormValid) {
+                  e.preventDefault();
+                }
+              }}
             >
               예약하기
             </RegisterButton>

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -4,14 +4,23 @@ import { useState } from 'react';
 
 import { useParams } from 'next/navigation';
 
-import { Calendar as CalendarIcon } from 'lucide-react';
+import { Calendar as CalendarIcon, CircleCheck } from 'lucide-react';
 
 import { Calendar } from '@/components/ui/calendar';
+import DeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { FlatTab } from '@/shared/ui/FlatTab/FlatTab';
 import { Header_Detail } from '@/shared/ui/Header_Detail';
+import { RegisterButton } from '@/shared/ui/RegisterButton/RegisterButton';
 
 import type { DateRange } from 'react-day-picker';
+
+// 예시 mock 데이터
+const mockDevices = [
+  { id: 1, name: '기기 이름', price: '10,000원', image: '' },
+  { id: 2, name: '기기 이름', price: '10,000원', image: '' },
+  { id: 3, name: '기기 이름', price: '10,000원', image: '' },
+];
 
 const ReservationPage = () => {
   const params = useParams();
@@ -36,9 +45,10 @@ const ReservationPage = () => {
       <FlatTab items={tabList} value={tab} onValueChange={setTab} />
       {tab === '예약' && (
         <div className="flex flex-col gap-4 mt-4 w-full">
+          {/* 날짜 선택 */}
           <div className="font-body-semibold text-lg flex items-center gap-2">
             <CalendarIcon size={20} className="text-[var(--main-5)]" />
-            날짜를 선택해주세요
+            날짜를 선택해 주세요
           </div>
           <div className="w-full">
             <Calendar
@@ -48,6 +58,82 @@ const ReservationPage = () => {
               required
               className="rounded-md w-full"
             />
+          </div>
+          {/* 기기 선택 */}
+          <div className="font-body-semibold text-lg flex items-center gap-2 mt-6">
+            <CircleCheck size={28} className="text-[var(--main-5)]" />
+            기기를 선택해 주세요
+          </div>
+          {/* 가로 스크롤 디바이스 카드 */}
+          <div className="flex flex-row gap-6 overflow-x-auto pb-2 pl-1">
+            {mockDevices.map((device) => (
+              <DeviceCard
+                key={device.id}
+                name={device.name}
+                price={device.price}
+                image={device.image}
+              />
+            ))}
+          </div>
+          {/* 안내사항 및 예약하기 버튼 */}
+          <div className="mt-6 w-full flex flex-col items-center">
+            <div className="w-full bg-white rounded-xl px-2 pt-4 pb-2 text-black">
+              <div className="font-body-semibold mt-5 mb-10 text-center">
+                아래 주의 사항을 꼭 읽어보시고
+                <br />
+                약관 내용에 동의해 주세요
+              </div>
+              <ul className="list-disc pl-5 space-y-1 font-label-regular">
+                <li>
+                  기기는 반드시{' '}
+                  <span className="text-[var(--main-5)] font-semibold">
+                    대여 신청 당일 대리점 영업시간 내에 수령
+                  </span>
+                  하셔야 합니다.
+                </li>
+                <li>
+                  대여 신청 당일에 수령하지 않을 시 해당 기기에 대한 예약 내역은{' '}
+                  <span className="text-[var(--main-5)] font-semibold">자동 취소</span>되오니 신중히
+                  예약 부탁드립니다.
+                </li>
+                <li>
+                  반납은{' '}
+                  <span className="text-[var(--main-5)] font-semibold">
+                    대여 종료일 당일 대리점 영업시간 내에
+                  </span>{' '}
+                  하셔야 합니다.
+                </li>
+                <li>
+                  기기 미반납 시{' '}
+                  <span className="text-[var(--main-5)] font-semibold">
+                    연체료 및 기기 손해배상금
+                  </span>
+                  이 발생하며, 법적 조치를 취할 수 있습니다.
+                </li>
+                <li>
+                  단말기에 대한 손실 및 파손 발생 시,{' '}
+                  <span className="text-[var(--main-5)] font-semibold">추가 비용</span>이 발생할 수
+                  있습니다.
+                </li>
+                <li>
+                  분실/파손/기기 반환지연이 반복적으로 발생되는 경우, 고객은{' '}
+                  <span className="text-[var(--main-5)] font-semibold">즉시 대여이용이 제한</span>될
+                  수 있습니다.
+                </li>
+                <li>
+                  단말기 대리점으로 연락하지 않고 미반납/미수령 시, 대리점은 이에 대한{' '}
+                  <span className="text-[var(--main-5)] font-semibold">책임이 없습니다</span>.
+                </li>
+              </ul>
+              <div className="my-10 text-center font-label-medium">위 사항에 동의하십니까?</div>
+            </div>
+            <RegisterButton
+              className="w-full bg-[var(--main-5)] text-white mb-10"
+              size="lg"
+              isFormValid={false}
+            >
+              예약하기
+            </RegisterButton>
           </div>
         </div>
       )}

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -7,13 +7,13 @@ import { useParams } from 'next/navigation';
 import { Calendar as CalendarIcon, CircleCheck } from 'lucide-react';
 
 import { Calendar } from '@/components/ui/calendar';
-import DeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { FlatTab } from '@/shared/ui/FlatTab/FlatTab';
 import { Header_Detail } from '@/shared/ui/Header_Detail';
 import { RegisterButton } from '@/shared/ui/RegisterButton/RegisterButton';
 
 import type { DateRange } from 'react-day-picker';
+import ReservationDeviceCard from '@/pages/rental/map/ui/ReservationDeviceCard';
 
 // 예시 mock 데이터
 const mockDevices = [
@@ -29,6 +29,8 @@ const ReservationPage = () => {
   const [tab, setTab] = useState('예약');
   const [selectedRange, setSelectedRange] = useState<DateRange | undefined>(undefined);
   const [agreed, setAgreed] = useState(false);
+  // 1. 상태 추가
+  const [selectedDeviceId, setSelectedDeviceId] = useState<number | null>(null);
 
   const tabList = [
     { label: '예약', value: '예약' },
@@ -68,11 +70,13 @@ const ReservationPage = () => {
           {/* 가로 스크롤 디바이스 카드 */}
           <div className="flex flex-row gap-6 overflow-x-auto pb-2 pl-1">
             {mockDevices.map((device) => (
-              <DeviceCard
+              <ReservationDeviceCard
                 key={device.id}
                 name={device.name}
                 price={device.price}
                 image={device.image}
+                selected={selectedDeviceId === device.id}
+                onClick={() => setSelectedDeviceId(device.id)}
               />
             ))}
           </div>

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -53,12 +53,12 @@ const ReservationPage = () => {
           <div className="fixed bottom-0 left-0 w-full z-30"></div>
           {/* 스크롤 가능한 컨텐츠 영역 */}
           <div
-            className="pt-28 pb-16 overflow-y-auto"
+            className="pt-10 pb-16 overflow-y-auto"
             style={{ height: '100vh', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
           >
             <style>{`.scrollbar-hide::-webkit-scrollbar { display: none; }`}</style>
             {tab === '예약' && (
-              <div className="flex flex-col gap-4 mt-4 w-full">
+              <div className="flex flex-col gap-4 w-full">
                 {/* 날짜 선택 */}
                 <CalendarSection
                   dateRange={state.dateRange}

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -1,1 +1,58 @@
-//예약 페이지
+'use client';
+
+import { useState } from 'react';
+
+import { useParams } from 'next/navigation';
+
+import { Calendar as CalendarIcon } from 'lucide-react';
+
+import { Calendar } from '@/components/ui/calendar';
+import { BaseLayout } from '@/shared/ui/BaseLayout';
+import { FlatTab } from '@/shared/ui/FlatTab/FlatTab';
+import { Header_Detail } from '@/shared/ui/Header_Detail';
+
+import type { DateRange } from 'react-day-picker';
+
+const ReservationPage = () => {
+  const params = useParams();
+  const storeId =
+    typeof params === 'object' && params !== null ? (params['storeId'] as string) : '';
+  const [tab, setTab] = useState('예약');
+  const [selectedRange, setSelectedRange] = useState<DateRange | undefined>(undefined);
+
+  const tabList = [
+    { label: '예약', value: '예약' },
+    { label: '상세정보', value: '상세정보' },
+    { label: '리뷰', value: '리뷰' },
+  ];
+
+  return (
+    <BaseLayout
+      header={<Header_Detail title={`LG유플러스 플러자 ${storeId}호점`} />}
+      showHeader
+      showBottomNav
+      className="custom-scrollbar"
+    >
+      <FlatTab items={tabList} value={tab} onValueChange={setTab} />
+      {tab === '예약' && (
+        <div className="flex flex-col gap-4 mt-4 w-full">
+          <div className="font-body-semibold text-lg flex items-center gap-2">
+            <CalendarIcon size={20} className="text-[var(--main-5)]" />
+            날짜를 선택해주세요
+          </div>
+          <div className="w-full">
+            <Calendar
+              mode="range"
+              selected={selectedRange}
+              onSelect={setSelectedRange}
+              required
+              className="rounded-md w-full"
+            />
+          </div>
+        </div>
+      )}
+    </BaseLayout>
+  );
+};
+
+export default ReservationPage;

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -4,25 +4,17 @@ import { useReducer, useState } from 'react';
 
 import { useParams } from 'next/navigation';
 
+import { mockReservationDevices } from '@/pages/rental/map/__mocks__/reservationDeviceCard.mock';
+import { initialState, reducer } from '@/pages/rental/store/reservation/model/reservationReducer';
+import CalendarSection from '@/pages/rental/store/reservation/page/CalendarSection';
+import DeviceSelectSection from '@/pages/rental/store/reservation/page/DeviceSelectSection';
+import NoticeSection from '@/pages/rental/store/reservation/page/NoticeSection';
+import ReceiptSection from '@/pages/rental/store/reservation/page/ReceiptSection';
 import { makeToast } from '@/shared/lib/makeToast';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { FlatTab } from '@/shared/ui/FlatTab/FlatTab';
 import { Header_Detail } from '@/shared/ui/Header_Detail';
 import { RegisterButton } from '@/shared/ui/RegisterButton/RegisterButton';
-
-import { initialState, reducer } from '../model/reservationReducer';
-
-import CalendarSection from './CalendarSection';
-import DeviceSelectSection from './DeviceSelectSection';
-import NoticeSection from './NoticeSection';
-import ReceiptSection from './ReceiptSection';
-
-// 예시 mock 데이터
-const mockDevices = [
-  { id: 1, name: '기기 이름', price: '10,000원', image: '' },
-  { id: 2, name: '기기 이름', price: '10,000원', image: '' },
-  { id: 3, name: '기기 이름', price: '10,000원', image: '' },
-];
 
 const ReservationPage = () => {
   const params = useParams();
@@ -68,7 +60,14 @@ const ReservationPage = () => {
           />
           {/* 기기 선택 */}
           <DeviceSelectSection
-            devices={mockDevices}
+            devices={mockReservationDevices.map((device) => ({
+              id: device.id,
+              deviceName: device.deviceName,
+              imageUrl: device.imageUrl,
+              dataCapacity: device.dataCapacity,
+              remainCount: device.remainCount,
+              price: device.price,
+            }))}
             selectedDeviceId={state.selectedDeviceId}
             onSelect={(id) => dispatch({ type: 'SET_SELECTED_DEVICE', payload: id })}
           />

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -15,6 +15,7 @@ import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { FlatTab } from '@/shared/ui/FlatTab/FlatTab';
 import { Header_Detail } from '@/shared/ui/Header_Detail';
 import { RegisterButton } from '@/shared/ui/RegisterButton/RegisterButton';
+import { Toaster } from '@/shared/ui/Toaster/Toaster';
 
 const ReservationPage = () => {
   const params = useParams();
@@ -44,83 +45,84 @@ const ReservationPage = () => {
   })();
 
   return (
-    <BaseLayout
-      header={<Header_Detail title={`LG유플러스 플러자 ${storeId}호점`} />}
-      showHeader
-      showBottomNav
-      className="custom-scrollbar"
-    >
-      <FlatTab items={tabList} value={tab} onValueChange={setTab} />
-      {tab === '예약' && (
-        <div className="flex flex-col gap-4 mt-4 w-full">
-          {/* 날짜 선택 */}
-          <CalendarSection
-            dateRange={state.dateRange}
-            onChange={(range) => dispatch({ type: 'SET_DATE_RANGE', payload: range })}
-          />
-          {/* 기기 선택 */}
-          <DeviceSelectSection
-            devices={mockReservationDevices.map((device) => ({
-              id: device.id,
-              deviceName: device.deviceName,
-              imageUrl: device.imageUrl,
-              dataCapacity: device.dataCapacity,
-              remainCount: device.remainCount,
-              price: device.price,
-            }))}
-            selectedDeviceId={state.selectedDeviceId}
-            onSelect={(id) => dispatch({ type: 'SET_SELECTED_DEVICE', payload: id })}
-          />
-          {/* 안내사항 및 예약하기 버튼 */}
-          <div className="mt-6 w-full flex flex-col items-center">
-            <NoticeSection
-              agreed={state.agreed}
-              onToggleAgreed={() => dispatch({ type: 'SET_AGREED', payload: !state.agreed })}
-            />
-            <RegisterButton
-              className={`w-full mb-10 ${isFormValid ? 'bg-[var(--main-5)] text-white' : 'bg-[var(--gray)] text-white'}`}
-              size="lg"
-              isFormValid={isFormValid}
-              onClick={(e) => {
-                if (!isFormValid) {
-                  e.preventDefault();
-                  return;
-                }
-                if (!isDateFuture) {
-                  makeToast('날짜를 다시 선택해주세요', 'warning');
-                  e.preventDefault();
-                  return;
-                }
-                setShowReceiptModal(true);
-              }}
-            >
-              예약하기
-            </RegisterButton>
+    <>
+      <BaseLayout header={<Header_Detail title={`LG유플러스 플러자 ${storeId}호점`} />}>
+        <Toaster />
+        <div className="relative min-h-screen bg-white scrollbar-hide">
+          <div className="fixed bottom-0 left-0 w-full z-30"></div>
+          {/* 스크롤 가능한 컨텐츠 영역 */}
+          <div
+            className="pt-14 pb-16 overflow-y-auto"
+            style={{ height: '100vh', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+          >
+            <style>{`.scrollbar-hide::-webkit-scrollbar { display: none; }`}</style>
+            <FlatTab items={tabList} value={tab} onValueChange={setTab} />
+            {tab === '예약' && (
+              <div className="flex flex-col gap-4 mt-4 w-full">
+                {/* 날짜 선택 */}
+                <CalendarSection
+                  dateRange={state.dateRange}
+                  onChange={(range) => dispatch({ type: 'SET_DATE_RANGE', payload: range })}
+                />
+                {/* 기기 선택 */}
+                <DeviceSelectSection
+                  devices={mockReservationDevices}
+                  selectedDeviceId={state.selectedDeviceId}
+                  onSelect={(id) => dispatch({ type: 'SET_SELECTED_DEVICE', payload: id })}
+                />
+                {/* 안내사항 및 예약하기 버튼 */}
+                <div className="mt-6 w-full flex flex-col items-center">
+                  <NoticeSection
+                    agreed={state.agreed}
+                    onToggleAgreed={() => dispatch({ type: 'SET_AGREED', payload: !state.agreed })}
+                  />
+                  <RegisterButton
+                    className={`w-full mb-10 ${isFormValid ? 'bg-[var(--main-5)] text-white' : 'bg-[var(--gray)] text-white'}`}
+                    size="lg"
+                    isFormValid={isFormValid}
+                    onClick={(e) => {
+                      if (!isFormValid) {
+                        e.preventDefault();
+                        return;
+                      }
+                      if (!isDateFuture) {
+                        makeToast('날짜를 다시 선택해주세요', 'warning');
+                        e.preventDefault();
+                        return;
+                      }
+                      setShowReceiptModal(true);
+                    }}
+                  >
+                    예약하기
+                  </RegisterButton>
+                </div>
+              </div>
+            )}
+            {/* Receipt 모달 */}
+            {showReceiptModal && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+                <div className="relative">
+                  <ReceiptSection
+                    periodDate="2025.05.02~2025.05.03"
+                    periodDays="(2일)"
+                    devices={[
+                      { name: '포켓 와이파이 A', price: '15,000원', count: 1 },
+                      { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                      { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                      { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                      { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                      { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                    ]}
+                    onPay={() => setShowReceiptModal(false)}
+                    onClose={() => setShowReceiptModal(false)}
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </div>
-      )}
-      {/* Receipt 모달 */}
-      {showReceiptModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="relative">
-            <ReceiptSection
-              periodDate="2025.05.02~2025.05.03"
-              periodDays="(2일)"
-              devices={[
-                { name: '포켓 와이파이 A', price: '15,000원', count: 1 },
-                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
-                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
-                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
-                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
-                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
-              ]}
-              onPay={() => setShowReceiptModal(false)}
-              onClose={() => setShowReceiptModal(false)}
-            />
-          </div>
-        </div>
-      )}
-    </BaseLayout>
+      </BaseLayout>
+    </>
   );
 };
 

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -15,6 +15,7 @@ import { initialState, reducer } from '../model/reservationReducer';
 import CalendarSection from './CalendarSection';
 import DeviceSelectSection from './DeviceSelectSection';
 import NoticeSection from './NoticeSection';
+import ReceiptSection from './ReceiptSection';
 
 // 예시 mock 데이터
 const mockDevices = [
@@ -29,6 +30,7 @@ const ReservationPage = () => {
     typeof params === 'object' && params !== null ? (params['storeId'] as string) : '';
   const [tab, setTab] = useState('예약');
   const [state, dispatch] = useReducer(reducer, initialState);
+  const [showReceiptModal, setShowReceiptModal] = useState(false);
 
   const tabList = [
     { label: '예약', value: '예약' },
@@ -88,11 +90,34 @@ const ReservationPage = () => {
                 if (!isDateFuture) {
                   makeToast('날짜를 다시 선택해주세요', 'warning');
                   e.preventDefault();
+                  return;
                 }
+                setShowReceiptModal(true);
               }}
             >
               예약하기
             </RegisterButton>
+          </div>
+        </div>
+      )}
+      {/* Receipt 모달 */}
+      {showReceiptModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="relative">
+            <ReceiptSection
+              periodDate="2025.05.02~2025.05.03"
+              periodDays="(2일)"
+              devices={[
+                { name: '포켓 와이파이 A', price: '15,000원', count: 1 },
+                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+                { name: '포켓 와이파이 B', price: '20,000원', count: 2 },
+              ]}
+              onPay={() => setShowReceiptModal(false)}
+              onClose={() => setShowReceiptModal(false)}
+            />
           </div>
         </div>
       )}

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -28,6 +28,7 @@ const ReservationPage = () => {
     typeof params === 'object' && params !== null ? (params['storeId'] as string) : '';
   const [tab, setTab] = useState('예약');
   const [selectedRange, setSelectedRange] = useState<DateRange | undefined>(undefined);
+  const [agreed, setAgreed] = useState(false);
 
   const tabList = [
     { label: '예약', value: '예약' },
@@ -125,12 +126,39 @@ const ReservationPage = () => {
                   <span className="text-[var(--main-5)] font-semibold">책임이 없습니다</span>.
                 </li>
               </ul>
-              <div className="my-10 text-center font-label-medium">위 사항에 동의하십니까?</div>
+              <div className="my-10 text-center font-label-medium flex items-center justify-center gap-2">
+                <button
+                  type="button"
+                  aria-checked={agreed}
+                  onClick={() => setAgreed((prev) => !prev)}
+                  className="w-6 h-6 rounded border-2 border-[var(--main-5)] flex items-center justify-center mr-2 focus:outline-none focus:ring-2 focus:ring-[var(--main-5)] bg-white"
+                  style={{ minWidth: 24 }}
+                >
+                  {agreed && (
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M4 8.5L7 11.5L12 5.5"
+                        stroke="#3e9fdc"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </button>
+                위 사항에 동의하십니까?
+              </div>
             </div>
             <RegisterButton
-              className="w-full bg-[var(--main-5)] text-white mb-10"
+              className={`w-full mb-10 ${agreed ? 'bg-[var(--main-5)] text-white' : 'bg-[var(--gray)] text-white'}`}
               size="lg"
-              isFormValid={false}
+              isFormValid={agreed}
             >
               예약하기
             </RegisterButton>

--- a/src/pages/rental/store/reservation/page/ReservationPage.tsx
+++ b/src/pages/rental/store/reservation/page/ReservationPage.tsx
@@ -49,14 +49,14 @@ const ReservationPage = () => {
       <BaseLayout header={<Header_Detail title={`LG유플러스 플러자 ${storeId}호점`} />}>
         <Toaster />
         <div className="relative min-h-screen bg-white scrollbar-hide">
+          <FlatTab items={tabList} value={tab} onValueChange={setTab} />
           <div className="fixed bottom-0 left-0 w-full z-30"></div>
           {/* 스크롤 가능한 컨텐츠 영역 */}
           <div
-            className="pt-14 pb-16 overflow-y-auto"
+            className="pt-28 pb-16 overflow-y-auto"
             style={{ height: '100vh', scrollbarWidth: 'none', msOverflowStyle: 'none' }}
           >
             <style>{`.scrollbar-hide::-webkit-scrollbar { display: none; }`}</style>
-            <FlatTab items={tabList} value={tab} onValueChange={setTab} />
             {tab === '예약' && (
               <div className="flex flex-col gap-4 mt-4 w-full">
                 {/* 날짜 선택 */}
@@ -77,7 +77,7 @@ const ReservationPage = () => {
                     onToggleAgreed={() => dispatch({ type: 'SET_AGREED', payload: !state.agreed })}
                   />
                   <RegisterButton
-                    className={`w-full mb-10 ${isFormValid ? 'bg-[var(--main-5)] text-white' : 'bg-[var(--gray)] text-white'}`}
+                    className={`w-full ${isFormValid ? 'bg-[var(--main-5)] text-white' : 'bg-[var(--gray)] text-white'}`}
                     size="lg"
                     isFormValid={isFormValid}
                     onClick={(e) => {

--- a/src/pages/rental/store/reservation/ui/DeviceReciptItem.tsx
+++ b/src/pages/rental/store/reservation/ui/DeviceReciptItem.tsx
@@ -7,7 +7,7 @@ const DeviceReceiptItem = ({
   price: string;
   count: number;
 }) => (
-  <div className="flex justify-between text-gray-400 text-sm">
+  <div className="flex justify-between text-[var(--gray-dark)] text-sm">
     <span>{name}</span>
     <span className="text-black">
       {price} x {count}

--- a/src/pages/rental/store/reservation/ui/DeviceReciptItem.tsx
+++ b/src/pages/rental/store/reservation/ui/DeviceReciptItem.tsx
@@ -1,0 +1,17 @@
+const DeviceReceiptItem = ({
+  name,
+  price,
+  count,
+}: {
+  name: string;
+  price: string;
+  count: number;
+}) => (
+  <div className="flex justify-between text-gray-400 text-sm">
+    <span>{name}</span>
+    <span className="text-black">
+      {price} x {count}
+    </span>
+  </div>
+);
+export default DeviceReceiptItem;

--- a/src/pages/rental/store/reservation/ui/index.ts
+++ b/src/pages/rental/store/reservation/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './DeviceReciptItem';

--- a/src/shared/ui/Header_Detail/Header_Detail.tsx
+++ b/src/shared/ui/Header_Detail/Header_Detail.tsx
@@ -1,6 +1,7 @@
+import Image from 'next/image';
+
 import { ICONS } from '@/shared/config/iconPath';
 import { HEADER_WIDTH } from '@/shared/config/ui';
-import Image from 'next/image';
 
 interface HeaderDetailProps {
   title: string;
@@ -17,7 +18,7 @@ export function Header_Detail({ title }: HeaderDetailProps) {
     >
       <div className="flex items-center justify-center w-[60px] h-[58px] absolute left-[24px] top-1/2 -translate-y-1/2">
         <Image
-          src={ICONS.ETC.BACKICON} 
+          src={ICONS.ETC.BACKICON}
           alt="뒤로가기"
           width={60}
           height={58}


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #125 

### 🔎 작업 내용
### 1️⃣ 전체 구조 및 UI 구현
- Header_Detail 컴포넌트 및 FlatTab(예약/상세정보/리뷰) 상단 고정
- BaseLayout 적용 및 import/linter 정리
- 스크롤바 숨김 처리 및 상하 패딩 조정

### 2️⃣ 예약 탭 기능
- 캘린더 UI 및 날짜 선택 기능 구현
- 날짜 유효성 검사(시작, 끝 날짜 >= 현재날짜)
- 예약하기 버튼 활성화 조건(날짜/기기/동의 체크 모두 선택)
- 예약관리 상태관리 Reducer 도입 및 상태 분리

### 3️⃣ 디바이스 UI 및 기능
- ReservationDeviceCard 컴포넌트 구현 및 mock 데이터 적용
- 기기 카드 UI 및 좌우 스크롤 적용
- 최대 수량 제한, 선택 마크업, 남은 기기 수 0대일 때 재입고 알림 표시
- 재입고 알림 신청/취소 UI 및 색상/글자 변경, toast 알림 처리
- memo, useCallback 등 최적화 적용(리렌더링 최소화)

### 4️⃣ 안내사항 및 약관 동의
- 안내사항(NoticeSection) 및 동의항목 UI/기능 구현
- 동의항목 추가 및 상태관리

### 5️⃣ 영수증 UI
- 대여 영수증 UI 1차/2차 마크업 및 기능 구현
- `X` 버튼 , 결제 버튼 누르면 모달 `Close` 
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/dac9e9ba-884b-4d57-97fd-a990eb8d1f45" />


### 6️⃣ 기타
- 코드 리팩토링(컴포넌트 분리, prop 시그니처 통일 등)
- linter 에러 및 import 순서 정리

### 📸 스크린샷
### 기본 전체 U
https://github.com/user-attachments/assets/1b58bbd7-25f3-4626-ba1b-33ee5cb67861

### 대여 기기 개수 선택 및 재입고 알림 토스트
https://github.com/user-attachments/assets/585cb422-35a3-4f59-b678-f30af61095b8

### 예약하기 전체 선택 필수 및 날짜 선택 유효성 검사
https://github.com/user-attachments/assets/ca69e926-42dc-44a1-9228-2ad0ba1e5a95

### 유효한 예약 선택 후 예약 확인용 영수증 UI

https://github.com/user-attachments/assets/ad66babc-db71-4f49-81e6-ae8392db9694




## :loudspeaker: 전달사항
#### API 연결 때 수정 예정
- 디바이스 선택에서 각 기기별 남은 공유기 수에 따라 숫자 증감 제한을 두려고 하는데 현재 각각이 아니라 총개수로 이상한 로직으로 증감 제한이 적용되고 있습니다. 
-  `{storeId}/device` 호출 시 response로 남은 공유기 대수도 함께 받도록 담당자 @dionisos198 에게 요청한 상태
- `선택한 디바이스 개수 및 가격을 종합 X 대여 기간` 으로 총합 가격 선정할 예정
- 현재 `FlatTab`에서 `예약` 으로 선택되어 있지 않습니다.  

