### PR TITLE
Feat: [BADA-218] 게시물 상세페이지 API 연동 마무리, UI 수정

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,6 +66,13 @@ const eslintConfig = [
       ],
     },
   },
+  // Storybook 파일들에 대해 perfectionist 규칙 비활성화
+  {
+    files: ['**/*.stories.tsx', '**/*.stories.ts'],
+    rules: {
+      'perfectionist/sort-imports': 'off',
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/trade/gifticon/[id]/page.tsx
+++ b/src/app/trade/gifticon/[id]/page.tsx
@@ -1,11 +1,11 @@
 import { getTradePostDetail } from '@/pages/trade/data/detail/api/apis';
-import { TradeDetailPage } from '@/pages/trade/data/detail/page/DataDetailPage';
+import { TradeDetailPage } from '@/pages/trade/gifticon/detail/page/GifticonDetailPage';
 
 interface Props {
   params: Promise<{ id: string }>;
 }
 
-export default async function DataDetailPage(props: Props) {
+export default async function GifticonDetailPage(props: Props) {
   const { params } = await props;
   const { id } = await params;
 

--- a/src/app/trade/report/[id]/page.tsx
+++ b/src/app/trade/report/[id]/page.tsx
@@ -1,12 +1,14 @@
 import { ReportPage } from '@/pages/trade/report/page/ReportPage';
 
 interface Props {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
-export default function ReportPostPage({ params }: Props) {
-  const id = parseInt(params.id);
 
-  return <ReportPage postId={id} />;
+export default async function ReportPostPage({ params }: Props) {
+  const { id } = await params;
+  const postId = parseInt(id);
+
+  return <ReportPage postId={postId} />;
 }

--- a/src/entities/auth/model/useKakaoCallback.ts
+++ b/src/entities/auth/model/useKakaoCallback.ts
@@ -35,5 +35,5 @@ export const useKakaoCallback = () => {
     };
 
     handleAuth();
-  }, []);
+  }, [login, router]);
 };

--- a/src/entities/trade-post/model/mutations.ts
+++ b/src/entities/trade-post/model/mutations.ts
@@ -7,6 +7,7 @@ import {
   postTradePostLike,
   reportTradePost,
 } from '@/entities/trade-post/api/apis';
+import { makeToast } from '@/shared/lib/makeToast';
 
 import type {
   AllPost,
@@ -15,7 +16,6 @@ import type {
   UpdatePostRequest,
   UpdatePostResponse,
 } from '@/entities/trade-post/lib/types';
-import { makeToast } from '@/shared/lib/makeToast';
 
 export const usePostTradePostLikeMutation = () => {
   const queryClient = useQueryClient();
@@ -65,6 +65,25 @@ export const useDeleteTradePostLikeMutation = () => {
       if (context?.previousPosts) {
         queryClient.setQueryData(['trade-posts'], context.previousPosts);
       }
+      console.error('좋아요 취소 실패', error);
+    },
+  });
+};
+
+// 상세페이지용 좋아요 뮤테이션 (optimistic update 없음)
+export const usePostTradePostLikeDetailMutation = () => {
+  return useMutation({
+    mutationFn: (postId: number) => postTradePostLike(postId),
+    onError: (error) => {
+      console.error('좋아요 처리 실패', error);
+    },
+  });
+};
+
+export const useDeleteTradePostLikeDetailMutation = () => {
+  return useMutation({
+    mutationFn: (postId: number) => deleteTradePostLike(postId),
+    onError: (error) => {
       console.error('좋아요 취소 실패', error);
     },
   });

--- a/src/entities/trade-post/model/useTradePostLikeHooks.ts
+++ b/src/entities/trade-post/model/useTradePostLikeHooks.ts
@@ -1,15 +1,21 @@
 import { useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import {
   useDeleteTradePostLikeMutation,
   usePostTradePostLikeMutation,
 } from '@/entities/trade-post/model/mutations';
 
 import type { AllPost } from '@/entities/trade-post/lib/types';
+import type { TradeDetailResponse } from '@/widgets/trade/post-detail/lib/types';
 
+// 통합된 좋아요 훅 (전체 페이지와 상세페이지 모두에서 사용)
 export const useTradePostLikeHooks = () => {
   const [loadingItems, setLoadingItems] = useState<Record<number, boolean>>({});
+  const queryClient = useQueryClient();
 
+  // 전체 페이지용 뮤테이션
   const postLikeMutation = usePostTradePostLikeMutation();
   const deleteLikeMutation = useDeleteTradePostLikeMutation();
 
@@ -20,17 +26,93 @@ export const useTradePostLikeHooks = () => {
     }));
   };
 
+  // 모든 관련 캐시 업데이트 함수
+  const updateAllCaches = (postId: number, newIsLiked: boolean) => {
+    // 전체 페이지 캐시 업데이트
+    queryClient.setQueryData(['trade-posts'], (oldData: AllPost[] | undefined) => {
+      if (!oldData) return oldData;
+      return oldData.map((post: AllPost) =>
+        post.id === postId
+          ? {
+              ...post,
+              isLiked: newIsLiked,
+              likesCount: newIsLiked ? post.likesCount + 1 : Math.max(0, post.likesCount - 1),
+            }
+          : post,
+      );
+    });
+
+    // 상세페이지 캐시 업데이트
+    queryClient.setQueryData(
+      ['trade', 'detail', postId],
+      (oldData: TradeDetailResponse | undefined) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          post: {
+            ...oldData.post,
+            isLiked: newIsLiked,
+            likesCount: newIsLiked
+              ? oldData.post.likesCount + 1
+              : Math.max(0, oldData.post.likesCount - 1),
+          },
+        };
+      },
+    );
+  };
+
+  // 전체 페이지용 토글
   const toggleLike = (item: AllPost) => {
     setItemLoading(item.id, true);
+
     if (item.isLiked) {
       deleteLikeMutation.mutate(item.id, {
+        onSuccess: () => {
+          updateAllCaches(item.id, false);
+        },
         onSettled: () => setItemLoading(item.id, false),
       });
     } else {
       postLikeMutation.mutate(item.id, {
+        onSuccess: () => {
+          updateAllCaches(item.id, true);
+        },
         onSettled: () => setItemLoading(item.id, false),
       });
     }
+  };
+
+  // 상세페이지용 토글 (단일 게시물)
+  const toggleLikeById = (postId: number, currentIsLiked: boolean) => {
+    setItemLoading(postId, true);
+
+    if (currentIsLiked) {
+      deleteLikeMutation.mutate(postId, {
+        onSuccess: () => {
+          updateAllCaches(postId, false);
+        },
+        onSettled: () => setItemLoading(postId, false),
+      });
+    } else {
+      postLikeMutation.mutate(postId, {
+        onSuccess: () => {
+          updateAllCaches(postId, true);
+        },
+        onSettled: () => setItemLoading(postId, false),
+      });
+    }
+  };
+
+  // 캐시에서 좋아요 상태 가져오기
+  const getCachedLikeState = (postId: number, fallbackIsLiked: boolean) => {
+    const cachedData = queryClient.getQueryData<AllPost[]>(['trade-posts']);
+    if (cachedData) {
+      const cachedPost = cachedData.find((post) => post.id === postId);
+      if (cachedPost) {
+        return cachedPost.isLiked;
+      }
+    }
+    return fallbackIsLiked;
   };
 
   const isItemLoading = (postId: number): boolean => {
@@ -38,8 +120,15 @@ export const useTradePostLikeHooks = () => {
   };
 
   return {
+    // 전체 페이지용
     toggleLike,
     isItemLoading,
+
+    // 상세페이지용
+    toggleLikeById,
+    getCachedLikeState,
+
+    // 공통
     isError: postLikeMutation.isError || deleteLikeMutation.isError,
     error: postLikeMutation.error || deleteLikeMutation.error,
   };

--- a/src/entities/user/api/apis.ts
+++ b/src/entities/user/api/apis.ts
@@ -1,7 +1,7 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import type { SalesItem, SalesResponse } from '@/entities/user/lib/types';
+import type { SalesResponse } from '@/entities/user/lib/types';
 import type { UserTradePostsResponse } from '@/widgets/trade/post-detail/lib/types';
 
 export const userApis = {
@@ -68,33 +68,15 @@ export const userApis = {
       : `${END_POINTS.USER.SALES}?${params}`;
 
     try {
-      const response = await axiosInstance.get(url);
-
-      if (!response) {
-        throw new Error('API 응답 데이터가 없습니다');
-      }
-
-      // response가 content인 경우 (인터셉터에 의해 변환됨)
-      if (response && typeof response === 'object' && 'item' in response) {
-        return {
-          code: 200,
-          message: null,
-          content: response as unknown as {
-            item: SalesItem[];
-            nextCursor: number;
-            hasNext: boolean;
-          },
-        } as SalesResponse;
-      }
-
-      // response가 전체 응답인 경우 (예상치 못한 상황)
-      if (response && typeof response === 'object' && 'data' in response) {
-        return response.data;
-      }
-
-      throw new Error('API 응답 형태가 올바르지 않습니다');
+      const response = await axiosInstance.get<SalesResponse['content']>(url);
+      return {
+        code: 20000,
+        message: null,
+        content: response.data,
+      };
     } catch (error) {
-      throw error;
+      console.error('Sales API 호출 실패:', error);
+      throw new Error('판매 내역을 불러오는데 실패했습니다.');
     }
   },
 

--- a/src/entities/user/api/apis.ts
+++ b/src/entities/user/api/apis.ts
@@ -1,6 +1,9 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
+import type { SalesItem, SalesResponse } from '@/entities/user/lib/types';
+import type { UserTradePostsResponse } from '@/widgets/trade/post-detail/lib/types';
+
 export const userApis = {
   // 팔로우/언팔로우 토글
   postFollowToggle: async (userId: number) => {
@@ -43,5 +46,84 @@ export const userApis = {
         following: isFollowing,
       },
     };
+  },
+
+  // 판매 내역 조회 (거래된 게시물)
+  getSales: async (
+    userId?: number,
+    postCategory?: string,
+    isSold?: boolean,
+    cursor?: number,
+    size: number = 30,
+  ): Promise<SalesResponse> => {
+    const params = new URLSearchParams();
+    if (postCategory) params.append('postCategory', postCategory);
+    if (isSold !== undefined) params.append('isSold', isSold.toString());
+    if (cursor !== undefined) params.append('cursor', cursor.toString());
+    params.append('size', size.toString());
+
+    // userId가 있으면 URL에 포함, 없으면 현재 사용자의 거래내역
+    const url = userId
+      ? `${END_POINTS.USER.SALES}/${userId}?${params}`
+      : `${END_POINTS.USER.SALES}?${params}`;
+
+    try {
+      const response = await axiosInstance.get(url);
+
+      if (!response) {
+        throw new Error('API 응답 데이터가 없습니다');
+      }
+
+      // response가 content인 경우 (인터셉터에 의해 변환됨)
+      if (response && typeof response === 'object' && 'item' in response) {
+        return {
+          code: 200,
+          message: null,
+          content: response as unknown as {
+            item: SalesItem[];
+            nextCursor: number;
+            hasNext: boolean;
+          },
+        } as SalesResponse;
+      }
+
+      // response가 전체 응답인 경우 (예상치 못한 상황)
+      if (response && typeof response === 'object' && 'data' in response) {
+        return response.data;
+      }
+
+      throw new Error('API 응답 형태가 올바르지 않습니다');
+    } catch (error) {
+      throw error;
+    }
+  },
+
+  // 특정 사용자의 거래된 총 게시물의 수 조회 (100개 이상이면 100+ 반환)
+  getUserSoldPostsCount: async (userId: number): Promise<number | string> => {
+    try {
+      const response = await axiosInstance.get(END_POINTS.TRADES.USER_POST(userId));
+
+      if (!response) {
+        return 0;
+      }
+
+      // response가 content인 경우 (인터셉터에 의해 변환됨)
+      if (response && typeof response === 'object' && 'soldedPostsResponse' in response) {
+        const userTradePosts = response as unknown as UserTradePostsResponse;
+        const soldedPosts = userTradePosts.soldedPostsResponse?.postsResponse || [];
+        const totalCount = soldedPosts.length;
+
+        // 100개 이상이면 "100+" 반환
+        if (totalCount >= 100) {
+          return '100+';
+        }
+
+        return totalCount;
+      }
+
+      return 0;
+    } catch {
+      return 0;
+    }
   },
 };

--- a/src/entities/user/api/apis.ts
+++ b/src/entities/user/api/apis.ts
@@ -1,8 +1,6 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import { userService } from '../services/userService';
-
 import type { FollowingsContent, SalesContent } from '@/entities/user/lib/types';
 import type { ApiResponse } from '@/shared/lib/axios/responseTypes';
 import type { UserTradePostsResponse } from '@/widgets/trade/post-detail/lib/types';
@@ -33,37 +31,24 @@ export const userApis = {
     cursor?: number,
     size: number = 30,
   ): Promise<ApiResponse<SalesContent>> => {
-    try {
-      const params = new URLSearchParams();
-      if (postCategory) params.append('postCategory', postCategory);
-      if (isSold !== undefined) params.append('isSold', isSold.toString());
-      if (cursor !== undefined) params.append('cursor', cursor.toString());
-      params.append('size', size.toString());
+    const params = new URLSearchParams();
+    if (postCategory) params.append('postCategory', postCategory);
+    if (isSold !== undefined) params.append('isSold', isSold.toString());
+    if (cursor !== undefined) params.append('cursor', cursor.toString());
+    params.append('size', size.toString());
 
-      const url = userId
-        ? `${END_POINTS.USER.SALES}/${userId}?${params}`
-        : `${END_POINTS.USER.SALES}?${params}`;
+    const url = userId
+      ? `${END_POINTS.USER.SALES}/${userId}?${params}`
+      : `${END_POINTS.USER.SALES}?${params}`;
 
-      const content: SalesContent = await axiosInstance.get(url);
-      return {
-        code: 20000,
-        message: undefined,
-        content,
-      };
-    } catch (error) {
-      console.error('Sales API 호출 실패:', error);
-      throw new Error('판매 내역을 불러오는데 실패했습니다.');
-    }
+    const response = await axiosInstance.get(url);
+    return response.data;
   },
 
-  getUserSoldPostsCount: async (userId: number): Promise<number | string> => {
-    try {
-      const userTradePosts: UserTradePostsResponse = await axiosInstance.get(
-        END_POINTS.TRADES.USER_POST(userId),
-      );
-      return userService.calculateSoldPostsCount(userTradePosts);
-    } catch {
-      return 0;
-    }
+  getUserTradePosts: async (userId: number): Promise<UserTradePostsResponse> => {
+    const userTradePosts: UserTradePostsResponse = await axiosInstance.get(
+      END_POINTS.TRADES.USER_POST(userId),
+    );
+    return userTradePosts;
   },
 };

--- a/src/entities/user/api/apis.ts
+++ b/src/entities/user/api/apis.ts
@@ -1,18 +1,22 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import type { SalesResponse } from '@/entities/user/lib/types';
+import { userService } from '../services/userService';
+
+import type { FollowingsContent, SalesContent } from '@/entities/user/lib/types';
+import type { ApiResponse } from '@/shared/lib/axios/responseTypes';
 import type { UserTradePostsResponse } from '@/widgets/trade/post-detail/lib/types';
 
 export const userApis = {
-  // 팔로우/언팔로우 토글
   postFollowToggle: async (userId: number) => {
     const response = await axiosInstance.post(END_POINTS.USER.FOLLOW(userId));
     return response.data;
   },
 
-  // 팔로잉 목록 조회
-  getFollowings: async (cursor?: number, size: number = 10) => {
+  getFollowings: async (
+    cursor?: number,
+    size: number = 10,
+  ): Promise<ApiResponse<FollowingsContent>> => {
     const params = new URLSearchParams();
     params.append('followType', 'FOLLOWINGS');
     if (cursor !== undefined) params.append('cursor', cursor.toString());
@@ -22,57 +26,29 @@ export const userApis = {
     return response.data;
   },
 
-  // 특정 사용자 팔로우 상태 확인
-  getFollowStatus: async (targetUserId: number) => {
-    let cursor: number | undefined;
-    let isFollowing = false;
-
-    do {
-      const data = await userApis.getFollowings(cursor, 100);
-      const items = data.content?.item || [];
-
-      if (items.some((user: { userId: number }) => user.userId === targetUserId)) {
-        isFollowing = true;
-        break;
-      }
-
-      cursor = data.content?.lastCursor;
-    } while (cursor);
-
-    return {
-      code: 20000,
-      message: null,
-      content: {
-        following: isFollowing,
-      },
-    };
-  },
-
-  // 판매 내역 조회 (거래된 게시물)
   getSales: async (
     userId?: number,
     postCategory?: string,
     isSold?: boolean,
     cursor?: number,
     size: number = 30,
-  ): Promise<SalesResponse> => {
-    const params = new URLSearchParams();
-    if (postCategory) params.append('postCategory', postCategory);
-    if (isSold !== undefined) params.append('isSold', isSold.toString());
-    if (cursor !== undefined) params.append('cursor', cursor.toString());
-    params.append('size', size.toString());
-
-    // userId가 있으면 URL에 포함, 없으면 현재 사용자의 거래내역
-    const url = userId
-      ? `${END_POINTS.USER.SALES}/${userId}?${params}`
-      : `${END_POINTS.USER.SALES}?${params}`;
-
+  ): Promise<ApiResponse<SalesContent>> => {
     try {
-      const response = await axiosInstance.get<SalesResponse['content']>(url);
+      const params = new URLSearchParams();
+      if (postCategory) params.append('postCategory', postCategory);
+      if (isSold !== undefined) params.append('isSold', isSold.toString());
+      if (cursor !== undefined) params.append('cursor', cursor.toString());
+      params.append('size', size.toString());
+
+      const url = userId
+        ? `${END_POINTS.USER.SALES}/${userId}?${params}`
+        : `${END_POINTS.USER.SALES}?${params}`;
+
+      const content: SalesContent = await axiosInstance.get(url);
       return {
         code: 20000,
-        message: null,
-        content: response.data,
+        message: undefined,
+        content,
       };
     } catch (error) {
       console.error('Sales API 호출 실패:', error);
@@ -80,30 +56,12 @@ export const userApis = {
     }
   },
 
-  // 특정 사용자의 거래된 총 게시물의 수 조회 (100개 이상이면 100+ 반환)
   getUserSoldPostsCount: async (userId: number): Promise<number | string> => {
     try {
-      const response = await axiosInstance.get(END_POINTS.TRADES.USER_POST(userId));
-
-      if (!response) {
-        return 0;
-      }
-
-      // response가 content인 경우 (인터셉터에 의해 변환됨)
-      if (response && typeof response === 'object' && 'soldedPostsResponse' in response) {
-        const userTradePosts = response as unknown as UserTradePostsResponse;
-        const soldedPosts = userTradePosts.soldedPostsResponse?.postsResponse || [];
-        const totalCount = soldedPosts.length;
-
-        // 100개 이상이면 "100+" 반환
-        if (totalCount >= 100) {
-          return '100+';
-        }
-
-        return totalCount;
-      }
-
-      return 0;
+      const userTradePosts: UserTradePostsResponse = await axiosInstance.get(
+        END_POINTS.TRADES.USER_POST(userId),
+      );
+      return userService.calculateSoldPostsCount(userTradePosts);
     } catch {
       return 0;
     }

--- a/src/entities/user/lib/types.ts
+++ b/src/entities/user/lib/types.ts
@@ -21,6 +21,27 @@ export interface FollowingsResponse {
   };
 }
 
+export interface SalesItem {
+  postId: number;
+  postCategory: string;
+  partner: string | null;
+  title: string;
+  price: number;
+  postLikes: number;
+  postImage: string | null;
+  isSold: boolean;
+}
+
+export interface SalesResponse {
+  code: number;
+  message: string | null;
+  content: {
+    item: SalesItem[];
+    nextCursor: number;
+    hasNext: boolean;
+  };
+}
+
 export interface UserProfile {
   id: number;
   name: string;

--- a/src/entities/user/lib/types.ts
+++ b/src/entities/user/lib/types.ts
@@ -1,24 +1,12 @@
-export interface FollowResponse {
-  code: number;
-  message: string | null;
-  content: {
-    following: boolean;
-  } | null;
-}
-
-export interface FollowingsResponse {
-  code: number;
-  message: string;
-  content: {
-    item: Array<{
-      id: number;
-      userId: number;
-      nickname: string;
-      profileImageUrl: string;
-    }>;
-    nextCursor: number;
-    hasNext: boolean;
-  };
+export interface FollowingsContent {
+  item: Array<{
+    id: number;
+    userId: number;
+    nickname: string;
+    profileImageUrl: string;
+  }>;
+  nextCursor: number;
+  hasNext: boolean;
 }
 
 export interface SalesItem {
@@ -32,14 +20,10 @@ export interface SalesItem {
   isSold: boolean;
 }
 
-export interface SalesResponse {
-  code: number;
-  message: string | null;
-  content: {
-    item: SalesItem[];
-    nextCursor: number;
-    hasNext: boolean;
-  };
+export interface SalesContent {
+  item: SalesItem[];
+  nextCursor: number;
+  hasNext: boolean;
 }
 
 export interface UserProfile {

--- a/src/entities/user/model/mutations.ts
+++ b/src/entities/user/model/mutations.ts
@@ -2,18 +2,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { userApis } from '@/entities/user/api/apis';
 
-import type { FollowResponse } from '@/entities/user/lib/types';
+import type { ApiResponse } from '@/shared/lib/axios/responseTypes';
 
 export const useCreateFollowMutation = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<FollowResponse, Error, number>({
+  return useMutation<ApiResponse<unknown>, Error, number>({
     mutationFn: (userId: number) => userApis.postFollowToggle(userId),
     onSuccess: (data, userId) => {
       // 팔로우/언팔로우 성공 시 관련 쿼리들을 무효화하여 UI를 업데이트
       queryClient.invalidateQueries({ queryKey: ['user', 'profile', userId] });
       queryClient.invalidateQueries({ queryKey: ['trade', 'seller', userId] });
-      queryClient.invalidateQueries({ queryKey: ['user', 'follow-status', userId] });
+      queryClient.invalidateQueries({ queryKey: ['user', 'followings'] });
     },
   });
 };

--- a/src/entities/user/model/mutations.ts
+++ b/src/entities/user/model/mutations.ts
@@ -14,6 +14,7 @@ export const useCreateFollowMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['user', 'profile', userId] });
       queryClient.invalidateQueries({ queryKey: ['trade', 'seller', userId] });
       queryClient.invalidateQueries({ queryKey: ['user', 'followings'] });
+      queryClient.invalidateQueries({ queryKey: ['user', 'all-followings'] });
     },
   });
 };

--- a/src/entities/user/model/queries.ts
+++ b/src/entities/user/model/queries.ts
@@ -2,13 +2,39 @@ import { useQuery } from '@tanstack/react-query';
 
 import { userApis } from '../api/apis';
 
-import type { FollowResponse } from '../lib/types';
+import type { FollowResponse, SalesResponse } from '@/entities/user/lib/types';
 
 // 팔로우 상태 조회 훅
 export const useFollowStatusQuery = (userId: number) => {
   return useQuery<FollowResponse>({
     queryKey: ['user', 'follow-status', userId],
     queryFn: () => userApis.getFollowStatus(userId),
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+// 판매 내역 조회 훅
+export const useSalesQuery = (
+  userId?: number,
+  postCategory?: string,
+  isSold?: boolean,
+  cursor?: number,
+  size: number = 30,
+) => {
+  return useQuery<SalesResponse>({
+    queryKey: ['user', 'sales', userId, postCategory, isSold, cursor, size],
+    queryFn: () => userApis.getSales(userId, postCategory, isSold, cursor, size),
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+// 특정 사용자의 거래된 총 게시물의 수 조회 훅
+export const useUserSoldPostsCountQuery = (userId?: number) => {
+  return useQuery<number | string>({
+    queryKey: ['user', 'sold-posts-count', userId],
+    queryFn: () => userApis.getUserSoldPostsCount(userId!),
     enabled: !!userId,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/entities/user/model/queries.ts
+++ b/src/entities/user/model/queries.ts
@@ -15,6 +15,43 @@ export const useFollowingsQuery = (cursor?: number, size: number = 10) => {
   });
 };
 
+// 모든 팔로잉 목록 조회 훅 (팔로우 상태 확인용)
+export const useAllFollowingsQuery = () => {
+  return useQuery<ApiResponse<FollowingsContent>>({
+    queryKey: ['user', 'all-followings'],
+    queryFn: async () => {
+      let allItems: Array<{
+        id: number;
+        userId: number;
+        nickname: string;
+        profileImageUrl: string;
+      }> = [];
+      let cursor: number | undefined;
+      let hasNext = true;
+
+      while (hasNext) {
+        const response = await userApis.getFollowings(cursor, 100); // 최대 100개씩 가져오기
+        const items = response.content?.item || [];
+        allItems = [...allItems, ...items];
+
+        hasNext = response.content?.hasNext || false;
+        cursor = response.content?.nextCursor;
+      }
+
+      return {
+        code: 20000,
+        message: undefined,
+        content: {
+          item: allItems,
+          nextCursor: 0,
+          hasNext: false,
+        },
+      };
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
 // 판매 내역 조회 훅
 export const useSalesQuery = (
   userId?: number,

--- a/src/entities/user/model/queries.ts
+++ b/src/entities/user/model/queries.ts
@@ -2,14 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { userApis } from '../api/apis';
 
-import type { FollowResponse, SalesResponse } from '@/entities/user/lib/types';
+import type { FollowingsContent, SalesContent } from '@/entities/user/lib/types';
+import type { ApiResponse } from '@/shared/lib/axios/responseTypes';
 
-// 팔로우 상태 조회 훅
-export const useFollowStatusQuery = (userId: number) => {
-  return useQuery<FollowResponse>({
-    queryKey: ['user', 'follow-status', userId],
-    queryFn: () => userApis.getFollowStatus(userId),
-    enabled: !!userId,
+// 팔로우 목록 조회 훅
+export const useFollowingsQuery = (cursor?: number, size: number = 10) => {
+  return useQuery<ApiResponse<FollowingsContent>>({
+    queryKey: ['user', 'followings', cursor, size],
+    queryFn: () => userApis.getFollowings(cursor, size),
     staleTime: 5 * 60 * 1000,
   });
 };
@@ -22,7 +22,7 @@ export const useSalesQuery = (
   cursor?: number,
   size: number = 30,
 ) => {
-  return useQuery<SalesResponse>({
+  return useQuery<ApiResponse<SalesContent>>({
     queryKey: ['user', 'sales', userId, postCategory, isSold, cursor, size],
     queryFn: () => userApis.getSales(userId, postCategory, isSold, cursor, size),
     enabled: !!userId,

--- a/src/entities/user/model/queries.ts
+++ b/src/entities/user/model/queries.ts
@@ -34,7 +34,10 @@ export const useSalesQuery = (
 export const useUserSoldPostsCountQuery = (userId?: number) => {
   return useQuery<number | string>({
     queryKey: ['user', 'sold-posts-count', userId],
-    queryFn: () => userApis.getUserSoldPostsCount(userId!),
+    queryFn: () => {
+      if (!userId) throw new Error('userId is required');
+      return userApis.getUserSoldPostsCount(userId);
+    },
     enabled: !!userId,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/pages/rental/store/reservation/ui/index.ts
+++ b/src/pages/rental/store/reservation/ui/index.ts
@@ -1,1 +1,1 @@
-export * from './DeviceReceiptItem';
+export { default as DeviceReceiptItem } from './DeviceReceiptItem';

--- a/src/pages/rental/store/reservation/ui/index.ts
+++ b/src/pages/rental/store/reservation/ui/index.ts
@@ -1,1 +1,1 @@
-export * from './DeviceReciptItem';
+export * from './DeviceReceiptItem';

--- a/src/pages/trade/data/detail/page/DataDetailPage.tsx
+++ b/src/pages/trade/data/detail/page/DataDetailPage.tsx
@@ -87,7 +87,6 @@ export const TradeDetailPage = ({ postUserId, post, postType, sellerName }: Prop
           <TradeDetailSellerSection
             sellerId={postUserId}
             sellerName={sellerName}
-            likesCount={post.likesCount}
             isFollowing={isFollowing ?? false}
             onFollowChange={setIsFollowing}
           />
@@ -96,7 +95,13 @@ export const TradeDetailPage = ({ postUserId, post, postType, sellerName }: Prop
 
       {/* 구매하기 버튼 */}
       <div className="fixed bottom-[84px] left-1/2 -translate-x-1/2 z-20">
-        <BuyButtonWithPayment postId={post.id} title={post.title} price={post.price} />
+        <BuyButtonWithPayment
+          postId={post.id}
+          title={post.title}
+          price={post.price}
+          initialIsLiked={post.isLiked}
+          isSold={post.isSold}
+        />
       </div>
 
       <TradeDetailDrawer

--- a/src/pages/trade/gifticon/detail/page/GifticonDetailPage.tsx
+++ b/src/pages/trade/gifticon/detail/page/GifticonDetailPage.tsx
@@ -87,7 +87,6 @@ export const TradeDetailPage = ({ postUserId, post, postType, sellerName }: Prop
           <TradeDetailSellerSection
             sellerId={postUserId}
             sellerName={sellerName}
-            likesCount={post.likesCount}
             isFollowing={isFollowing ?? false}
             onFollowChange={setIsFollowing}
           />
@@ -96,7 +95,13 @@ export const TradeDetailPage = ({ postUserId, post, postType, sellerName }: Prop
 
       {/* 구매하기 버튼 */}
       <div className="fixed bottom-[84px] left-1/2 -translate-x-1/2 z-20">
-        <BuyButtonWithPayment postId={post.id} title={post.title} price={post.price} />
+        <BuyButtonWithPayment
+          postId={post.id}
+          title={post.title}
+          price={post.price}
+          initialIsLiked={post.isLiked}
+          isSold={post.isSold}
+        />
       </div>
 
       <TradeDetailDrawer

--- a/src/pages/trade/register/gifticon/ui/GifticonEditForm.tsx
+++ b/src/pages/trade/register/gifticon/ui/GifticonEditForm.tsx
@@ -2,10 +2,8 @@ import { useEffect, useReducer } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import {
-  useTradePostDetailQuery,
-  useUpdateTradePostMutation,
-} from '@/entities/trade-post/model/queries';
+import { useUpdateTradePostMutation } from '@/entities/trade-post/model/mutations';
+import { useTradePostDetailQuery } from '@/entities/trade-post/model/queries';
 import {
   initialState,
   reducer,

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -24,6 +24,7 @@ export const END_POINTS = {
     REISSUE: '/api/v1/auth/reissue/token',
     FOLLOW: (userId: number) => `/api/v1/users/${userId}/follows`,
     GET_FOLLOWS: '/api/v1/users/follows',
+    SALES: '/api/v1/users/sales',
   },
   STORES: {
     ALLSTORE: (storeId: number) => `/api/v1/stores/${storeId}/devices`,

--- a/src/shared/ui/BackIcon/BackIcon.stories.tsx
+++ b/src/shared/ui/BackIcon/BackIcon.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { BackIcon } from './BackIcon';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta: Meta<typeof BackIcon> = {
   title: 'Components/BackIcon',

--- a/src/shared/ui/BackIcon/BackIcon.tsx
+++ b/src/shared/ui/BackIcon/BackIcon.tsx
@@ -1,5 +1,6 @@
-import { ICONS } from '@/shared/config/iconPath';
 import Image from 'next/image';
+
+import { ICONS } from '@/shared/config/iconPath';
 
 interface BackIconProps extends Omit<React.ComponentProps<typeof Image>, 'src'> {
   width?: number;

--- a/src/shared/ui/BuyButton/BuyButton.tsx
+++ b/src/shared/ui/BuyButton/BuyButton.tsx
@@ -30,7 +30,7 @@ export function BuyButton({
         type="button"
         onClick={onClick}
         disabled={isButtonDisabled}
-        className={`w-[300px] h-[55px] rounded-[20px] text-white flex items-center justify-center transition-colors min-w-0 min-h-0 ${
+        className={`w-[300px] h-[55px] rounded-[20px] text-[var(--white)] flex items-center justify-center transition-colors min-w-0 min-h-0 ${
           isButtonDisabled
             ? 'bg-[var(--gray-mid)] cursor-not-allowed'
             : 'bg-[var(--main-5)] active:bg-[var(--main-4)]'

--- a/src/shared/ui/BuyButton/BuyButton.tsx
+++ b/src/shared/ui/BuyButton/BuyButton.tsx
@@ -1,25 +1,42 @@
-import { LikeButtonCircle } from '@/shared/ui/LikeButtonCircle/LikeButtonCircle';
+import { DetailLikeButton } from '../LikeButton/DetailLikeButton';
 
 interface BuyButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   likeActive?: boolean;
   onLikeClick?: React.MouseEventHandler<HTMLButtonElement>;
   children?: React.ReactNode;
+  disabled?: boolean;
+  isSold?: boolean;
 }
 
-// TODO: 거래 완료 상태일 때 버튼 비활성화 및 '거래 완료' 텍스트 표시 기능 추가 예정
-export function BuyButton({ onClick, likeActive = false, onLikeClick, children }: BuyButtonProps) {
+export function BuyButton({
+  onClick,
+  likeActive = false,
+  onLikeClick,
+  children,
+  disabled = false,
+  isSold = false,
+}: BuyButtonProps) {
+  // 거래 완료 상태이거나 disabled 상태일 때 버튼 비활성화
+  const isButtonDisabled = disabled || isSold;
+
+  // 거래 완료 상태일 때 텍스트 변경
+  const buttonText = isSold ? '거래 완료' : (children ?? '구매하기');
+
   return (
     <div className="flex flex-row items-center gap-6">
-      <LikeButtonCircle active={likeActive} onClick={onLikeClick} />
+      <DetailLikeButton active={likeActive} onClick={onLikeClick} disabled={isButtonDisabled} />
       <button
         type="button"
         onClick={onClick}
-        className="w-[300px] h-[55px] rounded-[20px] bg-[var(--main-5)] active:bg-[var(--main-4)] text-white flex items-center justify-center transition-colors min-w-0 min-h-0"
+        disabled={isButtonDisabled}
+        className={`w-[300px] h-[55px] rounded-[20px] text-white flex items-center justify-center transition-colors min-w-0 min-h-0 ${
+          isButtonDisabled
+            ? 'bg-[var(--gray-mid)] cursor-not-allowed'
+            : 'bg-[var(--main-5)] active:bg-[var(--main-4)]'
+        }`}
       >
-        <span style={{ fontSize: 'var(--font-title-semibold)', fontWeight: 600 }}>
-          {children ?? '구매하기'}
-        </span>
+        <span className="font-body-semibold text-[var(--white)]">{buttonText}</span>
       </button>
     </div>
   );

--- a/src/shared/ui/DataUsageCard/DataUsageCard.tsx
+++ b/src/shared/ui/DataUsageCard/DataUsageCard.tsx
@@ -1,6 +1,8 @@
-import { cn } from '@/shared/lib/cn';
-import { cva } from 'class-variance-authority';
 import React, { forwardRef } from 'react';
+
+import { cva } from 'class-variance-authority';
+
+import { cn } from '@/shared/lib/cn';
 
 const cardWrapperVariants = cva(
   'w-full h-[225px] rounded-[20px] bg-white p-4 flex flex-col justify-between shadow-sm',

--- a/src/shared/ui/DatePicker/DatePicker.stories.tsx
+++ b/src/shared/ui/DatePicker/DatePicker.stories.tsx
@@ -23,7 +23,7 @@ export const Default: Story = {
   },
 };
 
-export const mobileDatePicker: Story = {
+export const MobileDatePicker: Story = {
   render: () => {
     const [date, setDate] = useState<Date | undefined>(new Date());
     return (

--- a/src/shared/ui/ImageCard/ImageCard.tsx
+++ b/src/shared/ui/ImageCard/ImageCard.tsx
@@ -8,10 +8,9 @@ interface ImageCardProps {
   size?: 'sm' | 'md' | 'lg';
   url?: string;
   expireDate?: string;
-  defaultLiked?: boolean;
 }
 
-export function ImageCard({ size = 'sm', url, expireDate, defaultLiked = false }: ImageCardProps) {
+export function ImageCard({ size = 'sm', url, expireDate }: ImageCardProps) {
   const dDayText = useExpireDateHooks(expireDate);
 
   return (

--- a/src/shared/ui/LikeButton/DetailLikeButton.tsx
+++ b/src/shared/ui/LikeButton/DetailLikeButton.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import Image from 'next/image';
+
+import { ICONS } from '@/shared/config/iconPath';
+
+interface DetailLikeButtonProps {
+  active?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  disabled?: boolean;
+}
+
+export function DetailLikeButton({
+  active = false,
+  onClick,
+  disabled = false,
+}: DetailLikeButtonProps) {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (onClick && !disabled) {
+      onClick(e);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      className={`w-[56px] h-[56px] p-0 border-none bg-[var(--white)] rounded-full flex items-center justify-center shadow-lg transition-all duration-200 ${
+        disabled
+          ? 'opacity-50 cursor-not-allowed scale-95'
+          : 'cursor-pointer hover:scale-105 active:scale-95'
+      }`}
+    >
+      <Image
+        src={active ? ICONS.ETC.LIKE_ACTIVE : ICONS.ETC.LIKE_NONACTIVE}
+        alt={active ? '좋아요 활성' : '좋아요 비활성'}
+        width={50}
+        height={50}
+        draggable={false}
+        className={`transition-all duration-200 ${disabled ? 'opacity-60' : ''}`}
+      />
+    </button>
+  );
+}

--- a/src/shared/ui/Product/Product.tsx
+++ b/src/shared/ui/Product/Product.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { ProductInfo } from '@/shared/ui/ProductInfo';
 import { Heart } from 'lucide-react';
+
+import { ProductInfo } from '@/shared/ui/ProductInfo';
+
 import { ImageBox } from '../ImageBox';
 
 export interface ProductProps {

--- a/src/shared/ui/Profile/Profile.tsx
+++ b/src/shared/ui/Profile/Profile.tsx
@@ -1,8 +1,9 @@
 import type { HTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
-import { cn } from '@/shared/lib/cn';
 import { cva } from 'class-variance-authority';
+
+import { cn } from '@/shared/lib/cn';
 
 import type { VariantProps } from 'class-variance-authority';
 

--- a/src/shared/ui/Review/ReviewCard.stories.tsx
+++ b/src/shared/ui/Review/ReviewCard.stories.tsx
@@ -1,7 +1,7 @@
 import { ReviewCard } from './ReviewCard';
 
+import type { ReviewCardProps } from '@/shared/ui/Review/ReviewCard';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import type { ReviewCardProps } from './ReviewCard';
 
 const meta: Meta<typeof ReviewCard> = {
   title: 'Components/ReviewCard',

--- a/src/shared/ui/Review/ReviewCard.stories.tsx
+++ b/src/shared/ui/Review/ReviewCard.stories.tsx
@@ -1,6 +1,7 @@
-import { ReviewCard, ReviewCardProps } from './ReviewCard';
+import { ReviewCard } from './ReviewCard';
 
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { ReviewCardProps } from './ReviewCard';
 
 const meta: Meta<typeof ReviewCard> = {
   title: 'Components/ReviewCard',

--- a/src/shared/ui/SectionDivider/SectionDivider.tsx
+++ b/src/shared/ui/SectionDivider/SectionDivider.tsx
@@ -1,8 +1,9 @@
 import type { HTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
-import { cn } from '@/shared/lib/cn';
 import { cva } from 'class-variance-authority';
+
+import { cn } from '@/shared/lib/cn';
 
 import type { VariantProps } from 'class-variance-authority';
 

--- a/src/shared/ui/Switch/Switch.stories.tsx
+++ b/src/shared/ui/Switch/Switch.stories.tsx
@@ -1,5 +1,5 @@
 import { Switch } from '@/components/ui/switch';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof Switch> = {

--- a/src/shared/ui/Switch/Switch.tsx
+++ b/src/shared/ui/Switch/Switch.tsx
@@ -1,6 +1,8 @@
-import { cn } from '@/shared/lib/cn';
-import { Root as SwitchRoot, Thumb as SwitchThumb } from '@radix-ui/react-switch';
 import type { ComponentPropsWithoutRef } from 'react';
+
+import { Root as SwitchRoot, Thumb as SwitchThumb } from '@radix-ui/react-switch';
+
+import { cn } from '@/shared/lib/cn';
 
 type BaseSwitchProps = ComponentPropsWithoutRef<typeof SwitchRoot>;
 

--- a/src/widgets/trade/payment/ui/BuyButtonWithPayment.tsx
+++ b/src/widgets/trade/payment/ui/BuyButtonWithPayment.tsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react';
+
+import { useTradePostLikeHooks } from '@/entities/trade-post/model/useTradePostLikeHooks';
 import { BuyButton } from '@/shared/ui/BuyButton/BuyButton';
 import { usePayment } from '@/widgets/trade/payment/model/usePayment';
 import PaymentStatusDrawer from '@/widgets/trade/payment/ui/PaymentStatusDrawer';
@@ -7,6 +10,8 @@ interface BuyButtonWithPaymentProps {
   title: string;
   price: number;
   children?: React.ReactNode;
+  initialIsLiked?: boolean;
+  isSold?: boolean; // 거래 완료 상태
 }
 
 export default function BuyButtonWithPayment({
@@ -14,20 +19,42 @@ export default function BuyButtonWithPayment({
   title,
   price,
   children = '구매하기',
+  initialIsLiked = false,
+  isSold = false,
 }: BuyButtonWithPaymentProps) {
+  const [currentIsLiked, setCurrentIsLiked] = useState(initialIsLiked);
+
   const { loading, isPaid, handlePayment, isDrawerOpen, closeDrawer } = usePayment(
     postId,
     title,
     price,
   );
 
+  const { toggleLikeById, getCachedLikeState, isItemLoading } = useTradePostLikeHooks();
+
+  // 캐시에서 좋아요 상태를 가져와서 동기화
+  useEffect(() => {
+    const cachedState = getCachedLikeState(postId, initialIsLiked);
+    setCurrentIsLiked(cachedState);
+  }, [postId, initialIsLiked, getCachedLikeState]);
+
+  const handleLikeClick = () => {
+    if (!isItemLoading(postId)) {
+      toggleLikeById(postId, currentIsLiked);
+      setCurrentIsLiked(!currentIsLiked);
+    }
+  };
+
   return (
     <>
       <BuyButton
         onClick={handlePayment}
-        // TODO: 버튼 비활성화 및 텍스트 변경은 BuyButton 내부에서 처리 필요
+        likeActive={currentIsLiked}
+        onLikeClick={handleLikeClick}
+        disabled={loading || isPaid || isItemLoading(postId)}
+        isSold={isSold}
       >
-        {isPaid ? '결제 완료' : loading ? '결제 처리 중...' : children}
+        {loading ? '결제 처리 중...' : children}
       </BuyButton>
       <PaymentStatusDrawer open={isDrawerOpen} onClose={closeDrawer} />
     </>

--- a/src/widgets/trade/post-detail/ui/TradeDetailDrawer.tsx
+++ b/src/widgets/trade/post-detail/ui/TradeDetailDrawer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
 import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
 
 import { AxiosError } from 'axios';
 import { Flag, Pencil, Trash2 } from 'lucide-react';

--- a/src/widgets/trade/post-detail/ui/TradeDetailSellerSection.tsx
+++ b/src/widgets/trade/post-detail/ui/TradeDetailSellerSection.tsx
@@ -9,10 +9,10 @@ import UserProfileCard from '@/widgets/user/ui/UserProfileCard';
 import type { AllPost } from '@/entities/trade-post/lib/types';
 
 interface TradeDetailSellerSectionProps {
-  sellerId: number; // 판매자 userId
+  sellerId: number;
   sellerName: string;
-  isFollowing: boolean; // 팔로우 여부
-  onFollowChange?: (isFollowing: boolean) => void; // 팔로우 상태 변경 콜백
+  isFollowing: boolean;
+  onFollowChange?: (isFollowing: boolean) => void;
 }
 
 export const TradeDetailSellerSection = ({
@@ -59,7 +59,7 @@ export const TradeDetailSellerSection = ({
             판매 중인 다른 상품이 없습니다.
           </div>
         ) : (
-          <div className="flex overflow-x-auto gap-4 mb-20 scrollbar-hide">
+          <div className="flex overflow-x-auto gap-4 mb-20 no-scrollbar">
             {posts.map((item) => {
               const updatedPost = getUpdatedPost(item);
               return (

--- a/src/widgets/trade/post-detail/ui/TradeDetailSellerSection.tsx
+++ b/src/widgets/trade/post-detail/ui/TradeDetailSellerSection.tsx
@@ -1,14 +1,16 @@
 'use client';
 
+import { useTradePostLikeHooks } from '@/entities/trade-post/model/useTradePostLikeHooks';
 import { ICONS } from '@/shared/config/iconPath';
 import { useUserTradePostsQuery } from '@/widgets/trade/post-detail/model/queries';
 import SellerPostCard from '@/widgets/trade/ui/SellerPostCard';
 import UserProfileCard from '@/widgets/user/ui/UserProfileCard';
 
+import type { AllPost } from '@/entities/trade-post/lib/types';
+
 interface TradeDetailSellerSectionProps {
   sellerId: number; // 판매자 userId
   sellerName: string;
-  likesCount: number;
   isFollowing: boolean; // 팔로우 여부
   onFollowChange?: (isFollowing: boolean) => void; // 팔로우 상태 변경 콜백
 }
@@ -16,20 +18,28 @@ interface TradeDetailSellerSectionProps {
 export const TradeDetailSellerSection = ({
   sellerId,
   sellerName,
-  likesCount,
   isFollowing,
   onFollowChange,
 }: TradeDetailSellerSectionProps) => {
   const { data, isLoading, error } = useUserTradePostsQuery(sellerId);
+  const { toggleLike, getCachedLikeState } = useTradePostLikeHooks();
 
   const posts = data?.soldingPostsResponse?.postsResponse || [];
+
+  // 캐시에서 최신 좋아요 상태를 가져오는 함수
+  const getUpdatedPost = (post: AllPost) => {
+    const cachedLikeState = getCachedLikeState(post.id, post.isLiked);
+    return {
+      ...post,
+      isLiked: cachedLikeState,
+    };
+  };
 
   return (
     <div className="mt-20">
       <UserProfileCard
         userId={sellerId}
         name={sellerName}
-        tradeCount={likesCount}
         isFollowing={isFollowing}
         onFollowChange={onFollowChange}
       />
@@ -50,18 +60,21 @@ export const TradeDetailSellerSection = ({
           </div>
         ) : (
           <div className="flex overflow-x-auto gap-4 mb-20 scrollbar-hide">
-            {posts.map((item) => (
-              <SellerPostCard
-                key={item.id}
-                imageUrl={item.postImage === 'no image' ? ICONS.LOGO.DETAIL : item.postImage}
-                title={item.title}
-                partner={item.partner || ''}
-                price={item.price}
-                likeCount={item.likesCount}
-                isLiked={item.isLiked}
-                onLikeChange={() => alert('좋아요 기능 연결 예정')}
-              />
-            ))}
+            {posts.map((item) => {
+              const updatedPost = getUpdatedPost(item);
+              return (
+                <SellerPostCard
+                  key={item.id}
+                  imageUrl={item.postImage === 'no image' ? ICONS.LOGO.DETAIL : item.postImage}
+                  title={item.title}
+                  partner={item.partner || ''}
+                  price={item.price}
+                  likeCount={item.likesCount}
+                  isLiked={updatedPost.isLiked}
+                  onLikeChange={() => toggleLike(updatedPost)}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/widgets/user/model/useFollowState.ts
+++ b/src/widgets/user/model/useFollowState.ts
@@ -1,19 +1,20 @@
 import { useEffect, useState } from 'react';
 
-import { useFollowStatusQuery } from '@/entities/user/model/queries';
+import { useFollowingsQuery } from '@/entities/user/model/queries';
 
 export const useFollowState = (userId: number) => {
   const [isFollowing, setIsFollowing] = useState<boolean | null>(null);
 
   // 서버에서 실제 팔로우 상태 조회
-  const { data: followStatusData, isLoading, error } = useFollowStatusQuery(userId);
+  const { data: followingsData, isLoading, error } = useFollowingsQuery();
 
   // 서버 데이터로 로컬 상태 초기화
   useEffect(() => {
-    if (followStatusData?.content?.following !== undefined) {
-      setIsFollowing(followStatusData.content.following);
+    if (followingsData?.content?.item) {
+      const isUserInFollowings = followingsData.content.item.some((user) => user.userId === userId);
+      setIsFollowing(isUserInFollowings);
     }
-  }, [followStatusData]);
+  }, [followingsData, userId]);
 
   // 팔로우 상태 변경 핸들러
   const handleFollowChange = (newFollowingState: boolean) => {

--- a/src/widgets/user/model/useFollowState.ts
+++ b/src/widgets/user/model/useFollowState.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 
-import { useFollowingsQuery } from '@/entities/user/model/queries';
+import { useAllFollowingsQuery } from '@/entities/user/model/queries';
 
 export const useFollowState = (userId: number) => {
   const [isFollowing, setIsFollowing] = useState<boolean | null>(null);
 
-  // 서버에서 실제 팔로우 상태 조회
-  const { data: followingsData, isLoading, error } = useFollowingsQuery();
+  // 모든 팔로잉 목록 조회
+  const { data: followingsData, isLoading, error } = useAllFollowingsQuery();
 
   // 서버 데이터로 로컬 상태 초기화
   useEffect(() => {

--- a/src/widgets/user/ui/UserProfileCard.tsx
+++ b/src/widgets/user/ui/UserProfileCard.tsx
@@ -42,18 +42,14 @@ const UserProfileCard = ({
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
-  // 팔로우 목록에서 현재 사용자가 있는지 확인
   const currentIsFollowing =
     followings?.content?.item?.some((user) => user.userId === userId) ?? isFollowing;
 
-  // 거래된 총 게시물의 수 (API에서 가져온 실제 데이터만 사용)
   const displayTradeCount = soldPostsCount ?? 0;
 
   const handleFollowClick = async () => {
     try {
       await createFollowMutation.mutateAsync(userId);
-
-      // 팔로우 상태가 변경되었으므로 콜백 호출
       onFollowClick?.();
     } catch (error: unknown) {
       console.error('팔로우/언팔로우 실패:', error);

--- a/src/widgets/user/ui/UserProfileCard.tsx
+++ b/src/widgets/user/ui/UserProfileCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { useCreateFollowMutation } from '@/entities/user/model/mutations';
-import { useFollowingsQuery, useUserSoldPostsCountQuery } from '@/entities/user/model/queries';
+import { useAllFollowingsQuery, useUserSoldPostsCountQuery } from '@/entities/user/model/queries';
 import { ErrorMessageMap } from '@/shared/config/errorCodes';
 import UserAvatar from '@/shared/ui/UserAvatar';
 
@@ -35,7 +35,7 @@ const UserProfileCard = ({
 }: UserProfileCardProps) => {
   const createFollowMutation = useCreateFollowMutation();
 
-  const { data: followings, isLoading: isLoadingFollowings } = useFollowingsQuery();
+  const { data: followings, isLoading: isLoadingFollowings } = useAllFollowingsQuery();
   const { data: soldPostsCount, isLoading: isLoadingSoldCount } =
     useUserSoldPostsCountQuery(userId);
 

--- a/src/widgets/user/ui/UserProfileCard.tsx
+++ b/src/widgets/user/ui/UserProfileCard.tsx
@@ -1,20 +1,19 @@
 import { useState } from 'react';
 
 import { useCreateFollowMutation } from '@/entities/user/model/mutations';
-import { useFollowStatusQuery } from '@/entities/user/model/queries';
+import { useFollowStatusQuery, useUserSoldPostsCountQuery } from '@/entities/user/model/queries';
 import { ErrorMessageMap } from '@/shared/config/errorCodes';
 import UserAvatar from '@/shared/ui/UserAvatar';
 
 import type { ErrorCode } from '@/shared/config/errorCodes';
 
 interface UserProfileCardProps {
-  userId: number; // 사용자 ID 추가
+  userId: number;
   name: string;
-  tradeCount: number;
   avatarSrc?: string;
   isFollowing?: boolean;
   onFollowClick?: () => void;
-  onFollowChange?: (isFollowing: boolean) => void; // 팔로우 상태 변경 콜백
+  onFollowChange?: (isFollowing: boolean) => void;
   className?: string;
 }
 
@@ -22,7 +21,6 @@ interface UserProfileCardProps {
  * UserProfileCard - 일반 사용자 프로필 카드
  * @param userId - 사용자 ID
  * @param name - 사용자 이름
- * @param tradeCount - 거래내역 수
  * @param avatarSrc - 아바타 이미지 URL
  * @param isFollowing - 팔로잉 상태 (초기값)
  * @param onFollowClick - 팔로우/팔로잉 버튼 클릭 핸들러
@@ -32,7 +30,6 @@ interface UserProfileCardProps {
 const UserProfileCard = ({
   userId,
   name,
-  tradeCount,
   avatarSrc,
   isFollowing = false,
   onFollowClick,
@@ -42,12 +39,17 @@ const UserProfileCard = ({
   const createFollowMutation = useCreateFollowMutation();
 
   const { data: followStatus, isLoading: isLoadingFollowStatus } = useFollowStatusQuery(userId);
+  const { data: soldPostsCount, isLoading: isLoadingSoldCount } =
+    useUserSoldPostsCountQuery(userId);
 
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
   // 서버 데이터가 있으면 우선, 없으면 prop fallback
   const currentIsFollowing = followStatus?.content?.following ?? isFollowing;
+
+  // 거래된 총 게시물의 수 (API에서 가져온 실제 데이터만 사용)
+  const displayTradeCount = soldPostsCount ?? 0;
 
   const handleFollowClick = async () => {
     try {
@@ -101,7 +103,7 @@ const UserProfileCard = ({
             </button>
           </div>
           <span className="text-[var(--black)] font-small-regular leading-none mt-2">
-            거래내역 {tradeCount}
+            거래내역 {isLoadingSoldCount ? '로딩중...' : displayTradeCount}
           </span>
         </div>
       </div>


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #133

### 🔎 작업 내용

- [x] 총 거래 게시물 수 API 연동 완료
- [X] 좋아요 API 연동 완료
  - 게시물 상세, 판매자의 다른 게시물 좋아요
- [X] 거래 완료된 게시물 구매하기 버튼 비활성화, 거래 완료 표시 띄우기

### 📸 스크린샷

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

### ✅ Check List

- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?
