### PR TITLE
Fix: [BADA-242] searchParams에 옵셔널 체이닝 추가

### DIFF
--- a/src/app/auth/kakao/callback/kakaoCallbackClient.tsx
+++ b/src/app/auth/kakao/callback/kakaoCallbackClient.tsx
@@ -9,7 +9,7 @@ import { useAuthStore } from '@/entities/auth/model/authStore';
 
 export default function KakaoCallbackClient() {
   const searchParams = useSearchParams();
-  const code = searchParams.get('code');
+  const code = searchParams?.get('code');
   const router = useRouter();
 
   const login = useAuthStore((state) => state.login);


### PR DESCRIPTION
### #️⃣연관된 이슈

> close: #149 

### 🔎 작업 내용

- [x] `searchParams.get(...)` → `searchParams?.get(...)`로 수정하여 Vercel 빌드 오류 해결
- [x] 해결 후 로그인 정상 동작하는지 테스트 완료

### 📸 스크린샷

### :loudspeaker: 전달사항
- 🚨 `searchParams` 관련 빌드 에러는 해결되었지만, `/mypage/like-store` 등에서 빌드 에러가 발생하고 있습니다!
- `/mypage/like-store`는 현재 다른 팀원이 리팩토링 작업중인 페이지로, 현재 브랜치에서 에러를 해결하는 것은 맞지 않다고 판단하였습니다.
- 현재 브랜치에서는 `searchParams` 옵셔널 체이닝만 추가하였으며, 다른 빌드 에러는 앞으로 PR 올리기 전에 각 도메인 담당자가 `npm run build`로 빌드 에러 확인 후 해결하여 올리는 것이 좋을 듯 합니다!!🙇‍♀️🙇‍♀️

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
