### PR TITLE
Feat: [BADA-249] 마이페이지 나의 찜한 게시물 글 API 연동

### DIFF
--- a/src/pages/mypage/follower/api/apis.ts
+++ b/src/pages/mypage/follower/api/apis.ts
@@ -1,0 +1,25 @@
+import { END_POINTS } from '@/shared/api/endpoints';
+import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
+
+import type { FollowerItem } from '@/pages/mypage/follower/lib/types';
+
+export interface FollowerResponse {
+  item: FollowerItem[];
+  nextCursor: number;
+  hasNext: boolean;
+}
+
+export const fetchFollowers = async (
+  cursor?: number,
+  size: number = 10,
+): Promise<FollowerResponse> => {
+  const response = await axiosInstance.get(END_POINTS.MYPAGE.FOLLOWERS, {
+    params: { 
+      followType: 'FOLLOWERS',
+      cursor, 
+      size 
+    },
+  });
+  
+  return response.data.content;
+}; 

--- a/src/pages/mypage/follower/api/apis.ts
+++ b/src/pages/mypage/follower/api/apis.ts
@@ -1,25 +1,29 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import type { FollowerItem } from '@/pages/mypage/follower/lib/types';
+import type { FollowerResponse } from '@/pages/mypage/follower/lib/types';
 
-export interface FollowerResponse {
-  item: FollowerItem[];
-  nextCursor: number;
-  hasNext: boolean;
-}
+const FOLLOW_TYPES = {
+  FOLLOWERS: 'FOLLOWERS',
+  FOLLOWINGS: 'FOLLOWINGS'
+} as const;
 
 export const fetchFollowers = async (
   cursor?: number,
   size: number = 10,
-): Promise<FollowerResponse> => {
-  const response = await axiosInstance.get(END_POINTS.MYPAGE.FOLLOWERS, {
-    params: { 
-      followType: 'FOLLOWERS',
-      cursor, 
-      size 
-    },
-  });
-  
-  return response.data.content;
+): Promise<FollowerResponse['content']> => {
+  try {
+    const response = await axiosInstance.get(END_POINTS.MYPAGE.FOLLOWERS, {
+      params: { 
+        followType: FOLLOW_TYPES.FOLLOWERS,
+        cursor, 
+        size 
+      },
+    });
+    
+    return response.data.content;
+  } catch (error) {
+    console.error('팔로워 목록 조회 실패:', error);
+    throw error;
+  }
 }; 

--- a/src/pages/mypage/follower/lib/types.ts
+++ b/src/pages/mypage/follower/lib/types.ts
@@ -1,0 +1,16 @@
+export interface FollowerItem {
+  id: number;
+  userId: number;
+  nickname: string;
+  profileImageUrl: string;
+}
+
+export interface FollowerResponse {
+  code: number;
+  message: string | null;
+  content: {
+    item: FollowerItem[];
+    nextCursor: number;
+    hasNext: boolean;
+  };
+} 

--- a/src/pages/mypage/follower/model/queries.ts
+++ b/src/pages/mypage/follower/model/queries.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchFollowers } from '@/pages/mypage/follower/api/apis';
+
+import type { FollowerItem } from '@/pages/mypage/follower/lib/types';
+
+export function useFollowers(cursor?: number, size: number = 10) {
+  const { data, isLoading, isError } = useQuery<{
+    item: FollowerItem[];
+    nextCursor: number;
+    hasNext: boolean;
+  }>({
+    queryKey: ['followers', cursor, size],
+    queryFn: () => fetchFollowers(cursor, size),
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+
+  return {
+    followerItems: data?.item ?? [],
+    nextCursor: data?.nextCursor,
+    hasNext: data?.hasNext,
+    isLoading,
+    isError,
+  };
+} 

--- a/src/pages/mypage/follower/page/FollowerPage.tsx
+++ b/src/pages/mypage/follower/page/FollowerPage.tsx
@@ -1,43 +1,41 @@
 'use client';
 
-import { useState } from 'react';
-
 import { useRouter } from 'next/navigation';
 
+import { useFollowers } from '@/pages/mypage/follower/model/queries';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { PageHeader } from '@/shared/ui/Header';
 import { Profile } from '@/shared/ui/Profile';
 
-const initialFollowers = [
-  { id: 1, name: '박아무개', avatar: '/assets/profile-default.png' },
-  { id: 2, name: '박아무개', avatar: '/assets/profile-default.png' },
-  { id: 3, name: '박아무개', avatar: '/assets/profile-default.png' },
-  { id: 4, name: '박아무개', avatar: '/assets/profile-default.png' },
-  { id: 5, name: '박아무개', avatar: '/assets/profile-default.png' },
-];
-
 export default function FollowerPage() {
-  const [followers, setFollowers] = useState(initialFollowers);
   const router = useRouter();
+  const { followerItems, isLoading, isError } = useFollowers();
+
+  if (isLoading) return <div>로딩중...</div>;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+  if (!followerItems || followerItems.length === 0) {
+    return <div className="py-4 text-center text-[var(--gray)]">팔로워가 없습니다.</div>;
+  }
 
   const handleRemove = (id: number) => {
-    setFollowers((prev) => prev.filter((user) => user.id !== id));
+    // TODO: 팔로워 차단 API 연동
+    console.log('팔로워 차단:', id);
   };
 
   return (
     <BaseLayout header={<PageHeader title="팔로워 목록" onBack={() => router.back()} />} showBottomNav>
-      <ul className="px-4 pt-6 pb-[96px] flex flex-col gap-4">
-        {followers.map((user) => (
-          <li key={user.id} className="w-full">
+      <div className="flex flex-col items-center gap-4 px-4 pt-6 pb-[96px]">
+        {followerItems.map((user) => (
+          <div key={user.id} className="w-full max-w-[400px] flex justify-center">
             <Profile
-              name={user.name}
-              avatar={user.avatar}
+              name={user.nickname}
+              avatar={user.profileImageUrl}
               showCloseButton
-              onClose={() => handleRemove(user.id)}
+              onClose={() => handleRemove(user.userId)}
             />
-          </li>
+          </div>
         ))}
-      </ul>
+      </div>
     </BaseLayout>
   );
 } 

--- a/src/pages/mypage/following/api/apis.ts
+++ b/src/pages/mypage/following/api/apis.ts
@@ -1,24 +1,29 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import type { FollowingItem } from '@/pages/mypage/following/lib/types';
+import type { FollowingResponse } from '@/pages/mypage/following/lib/types';
 
-export interface FollowingResponse {
-  item: FollowingItem[];
-  nextCursor: number;
-  hasNext: boolean;
-}
+const FOLLOW_TYPES = {
+  FOLLOWERS: 'FOLLOWERS',
+  FOLLOWINGS: 'FOLLOWINGS'
+} as const;
 
 export const fetchFollowings = async (
   cursor?: number,
   size: number = 10,
-): Promise<FollowingResponse> => {
-  const response = await axiosInstance.get(END_POINTS.MYPAGE.FOLLOWINGS, {
-    params: { 
-      followType: 'FOLLOWINGS',
-      cursor, 
-      size 
-    },
-  });
-  return response.data.content;
+): Promise<FollowingResponse['content']> => {
+  try {
+    const response = await axiosInstance.get(END_POINTS.MYPAGE.FOLLOWINGS, {
+      params: { 
+        followType: FOLLOW_TYPES.FOLLOWINGS,
+        cursor, 
+        size 
+      },
+    });
+    
+    return response.data.content;
+  } catch (error) {
+    console.error('팔로잉 목록 조회 실패:', error);
+    throw error;
+  }
 }; 

--- a/src/pages/mypage/following/api/apis.ts
+++ b/src/pages/mypage/following/api/apis.ts
@@ -1,0 +1,24 @@
+import { END_POINTS } from '@/shared/api/endpoints';
+import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
+
+import type { FollowingItem } from '@/pages/mypage/following/lib/types';
+
+export interface FollowingResponse {
+  item: FollowingItem[];
+  nextCursor: number;
+  hasNext: boolean;
+}
+
+export const fetchFollowings = async (
+  cursor?: number,
+  size: number = 10,
+): Promise<FollowingResponse> => {
+  const response = await axiosInstance.get(END_POINTS.MYPAGE.FOLLOWINGS, {
+    params: { 
+      followType: 'FOLLOWINGS',
+      cursor, 
+      size 
+    },
+  });
+  return response.data.content;
+}; 

--- a/src/pages/mypage/following/lib/types.ts
+++ b/src/pages/mypage/following/lib/types.ts
@@ -1,0 +1,16 @@
+export interface FollowingItem {
+  id: number;
+  userId: number;
+  nickname: string;
+  profileImageUrl: string;
+}
+
+export interface FollowingResponse {
+  code: number;
+  message: string | null;
+  content: {
+    item: FollowingItem[];
+    nextCursor: number;
+    hasNext: boolean;
+  };
+} 

--- a/src/pages/mypage/following/model/queries.ts
+++ b/src/pages/mypage/following/model/queries.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchFollowings } from '@/pages/mypage/following/api/apis';
+
+import type { FollowingItem } from '@/pages/mypage/following/lib/types';
+
+export function useFollowings(cursor?: number, size: number = 10) {
+  const { data, isLoading, isError } = useQuery<{
+    item: FollowingItem[];
+    nextCursor: number;
+    hasNext: boolean;
+  }>({
+    queryKey: ['followings', cursor, size],
+    queryFn: () => fetchFollowings(cursor, size),
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+
+  return {
+    followingItems: data?.item ?? [],
+    nextCursor: data?.nextCursor,
+    hasNext: data?.hasNext,
+    isLoading,
+    isError,
+  };
+} 

--- a/src/pages/mypage/following/page/FollowingPage.tsx
+++ b/src/pages/mypage/following/page/FollowingPage.tsx
@@ -1,41 +1,41 @@
 'use client';
 
-import { useState } from 'react';
-
 import { useRouter } from 'next/navigation';
 
+import { useFollowings } from '@/pages/mypage/following/model/queries';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { PageHeader } from '@/shared/ui/Header';
 import { Profile } from '@/shared/ui/Profile';
 
-const initialFollowings = [
-  { id: 1, name: '박아무개', avatar: '/assets/profile-default.png' },
-  { id: 2, name: '박아무개', avatar: '/assets/profile-default.png' },
-  { id: 3, name: '박아무개', avatar: '/assets/profile-default.png' },
-];
-
 export default function FollowingPage() {
-  const [followings, setFollowings] = useState(initialFollowings);
   const router = useRouter();
+  const { followingItems, isLoading, isError } = useFollowings();
+
+  if (isLoading) return <div>로딩중...</div>;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+  if (!followingItems || followingItems.length === 0) {
+    return <div className="py-4 text-center text-[var(--gray)]">팔로잉이 없습니다.</div>;
+  }
 
   const handleRemove = (id: number) => {
-    setFollowings((prev) => prev.filter((user) => user.id !== id));
+    // TODO: 팔로우 취소 API 연동
+    console.log('팔로우 취소:', id);
   };
 
   return (
     <BaseLayout header={<PageHeader title="팔로잉 목록" onBack={() => router.back()} />} showBottomNav>
-      <ul className="px-4 pt-6 pb-[96px] flex flex-col gap-4">
-        {followings.map((user) => (
-          <li key={user.id} className="w-full">
+      <div className="flex flex-col items-center gap-4 px-4 pt-6 pb-[96px]">
+        {followingItems.map((user) => (
+          <div key={user.id} className="w-full max-w-[400px] flex justify-center">
             <Profile
-              name={user.name}
-              avatar={user.avatar}
+              name={user.nickname}
+              avatar={user.profileImageUrl}
               showCloseButton
-              onClose={() => handleRemove(user.id)}
+              onClose={() => handleRemove(user.userId)}
             />
-          </li>
+          </div>
         ))}
-      </ul>
+      </div>
     </BaseLayout>
   );
 } 

--- a/src/pages/mypage/like-trade-post/api/apis.ts
+++ b/src/pages/mypage/like-trade-post/api/apis.ts
@@ -1,12 +1,12 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import type { LikeTradePostResponse } from '@/pages/mypage/like-trade-post/lib/types';
+import type { LikeTradePostContent } from '@/pages/mypage/like-trade-post/lib/types';
 
 export const fetchLikedTradePosts = async (
   cursor?: number,
   size: number = 10,
-): Promise<LikeTradePostResponse['content']> => {
+): Promise<LikeTradePostContent> => {
   return await axiosInstance.get(END_POINTS.MYPAGE.LIKE_TRADE_POST, {
     params: { cursor, size },
   });

--- a/src/pages/mypage/like-trade-post/api/apis.ts
+++ b/src/pages/mypage/like-trade-post/api/apis.ts
@@ -1,0 +1,13 @@
+import { END_POINTS } from '@/shared/api/endpoints';
+import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
+
+import type { LikeTradePostResponse } from '@/pages/mypage/like-trade-post/lib/types';
+
+export const fetchLikedTradePosts = async (
+  cursor?: number,
+  size: number = 10,
+): Promise<LikeTradePostResponse['content']> => {
+  return await axiosInstance.get(END_POINTS.MYPAGE.LIKE_TRADE_POST, {
+    params: { cursor, size },
+  });
+}; 

--- a/src/pages/mypage/like-trade-post/lib/types.ts
+++ b/src/pages/mypage/like-trade-post/lib/types.ts
@@ -1,0 +1,21 @@
+export interface LikeTradePostItem {
+  id: number;
+  postId: number;
+  postCategory: 'GIFTICON' | 'DATA';
+  partner: string;
+  title: string;
+  price: number;
+  postLikes: number;
+  postImage: string;
+  isSold: boolean;
+}
+
+export interface LikeTradePostResponse {
+  code: number;
+  message: string | null;
+  content: {
+    item: LikeTradePostItem[];
+    nextCursor: number;
+    hasNext: boolean;
+  };
+} 

--- a/src/pages/mypage/like-trade-post/lib/types.ts
+++ b/src/pages/mypage/like-trade-post/lib/types.ts
@@ -10,12 +10,14 @@ export interface LikeTradePostItem {
   isSold: boolean;
 }
 
+export interface LikeTradePostContent {
+  item: LikeTradePostItem[];
+  nextCursor: number;
+  hasNext: boolean;
+}
+
 export interface LikeTradePostResponse {
   code: number;
   message: string | null;
-  content: {
-    item: LikeTradePostItem[];
-    nextCursor: number;
-    hasNext: boolean;
-  };
+  content: LikeTradePostContent;
 } 

--- a/src/pages/mypage/like-trade-post/model/queries.ts
+++ b/src/pages/mypage/like-trade-post/model/queries.ts
@@ -2,14 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchLikedTradePosts } from '@/pages/mypage/like-trade-post/api/apis';
 
-import type { LikeTradePostItem } from '@/pages/mypage/like-trade-post/lib/types';
+import type { LikeTradePostContent } from '@/pages/mypage/like-trade-post/lib/types';
 
 export function useLikedTradePosts(cursor?: number, size: number = 10) {
-  const { data, isLoading, isError } = useQuery<{
-    item: LikeTradePostItem[];
-    nextCursor: number;
-    hasNext: boolean;
-  }>({
+  const { data, isLoading, isError } = useQuery<LikeTradePostContent>({
     queryKey: ['likedTradePosts', cursor, size],
     queryFn: () => fetchLikedTradePosts(cursor, size),
     staleTime: 1000 * 60 * 5,

--- a/src/pages/mypage/like-trade-post/model/queries.ts
+++ b/src/pages/mypage/like-trade-post/model/queries.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchLikedTradePosts } from '@/pages/mypage/like-trade-post/api/apis';
+
+import type { LikeTradePostItem } from '@/pages/mypage/like-trade-post/lib/types';
+
+export function useLikedTradePosts(cursor?: number, size: number = 10) {
+  const { data, isLoading, isError } = useQuery<{
+    item: LikeTradePostItem[];
+    nextCursor: number;
+    hasNext: boolean;
+  }>({
+    queryKey: ['likedTradePosts', cursor, size],
+    queryFn: () => fetchLikedTradePosts(cursor, size),
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+
+  return {
+    likeTradePostItems: data?.item ?? [],
+    nextCursor: data?.nextCursor,
+    hasNext: data?.hasNext,
+    isLoading,
+    isError,
+  };
+} 

--- a/src/pages/mypage/like-trade-post/page/LikeTradePost.tsx
+++ b/src/pages/mypage/like-trade-post/page/LikeTradePost.tsx
@@ -54,7 +54,7 @@ export default function LikeTradePostPage() {
               <button
                 onClick={handleLoadMore}
                 disabled={isLoading}
-                className="px-6 py-2 bg-blue-500 text-white rounded-lg disabled:opacity-50"
+                className="px-6 py-2 bg-[var(--main-5)] text-[var(--white)] rounded-lg disabled:opacity-50"
               >
                 {isLoading ? '로딩중...' : '더보기'}
               </button>

--- a/src/pages/mypage/like-trade-post/page/LikeTradePost.tsx
+++ b/src/pages/mypage/like-trade-post/page/LikeTradePost.tsx
@@ -1,58 +1,67 @@
 'use client';
 
+import { useState } from 'react';
+
 import { useRouter } from 'next/navigation';
 
+import { useLikedTradePosts } from '@/pages/mypage/like-trade-post/model/queries';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { PageHeader } from '@/shared/ui/Header';
 import TradePostCard from '@/widgets/trade/ui/TradePostCard';
 
-const dummyList = [
-  {
-    id: 1,
-    title: '쇼콜라 바니드라제휴처',
-    partner: '제휴처',
-    price: 2050,
-    likeCount: 5,
-    isLiked: true,
-    hasDday: true,
-    dday: 5,
-    imageUrl: '/assets/trade-detail.jpg',
-  },
-  {
-    id: 2,
-    title: '쇼콜라 바니드라제휴처',
-    partner: '제휴처',
-    price: 2050,
-    likeCount: 5,
-    isLiked: true,
-    hasDday: true,
-    dday: 5,
-    imageUrl: '/assets/trade-detail.jpg',
-  },
-];
-
 export default function LikeTradePostPage() {
   const router = useRouter();
+  const [cursor, setCursor] = useState<number | undefined>(undefined);
+  const { likeTradePostItems, nextCursor, hasNext, isLoading, isError } = useLikedTradePosts(cursor);
 
+  const handleLoadMore = () => {
+    if (hasNext && nextCursor) {
+      setCursor(nextCursor);
+    }
+  };
+
+  const handleBack = () => router.back();
+
+  if (isLoading && !cursor) return <div>로딩중...</div>;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+  
   return (
-    <BaseLayout header={<PageHeader title="찜 목록" onBack={() => router.back()} />} showBottomNav>
-      <div className="px-4 pt-4 pb-[96px]">
-        <div className="grid grid-cols-2 gap-4">
-          {dummyList.map((item) => (
-            <TradePostCard
-              key={item.id}
-              imageUrl={item.imageUrl}
-              title={item.title}
-              partner={item.partner}
-              price={item.price}
-              likeCount={item.likeCount}
-              isLiked={item.isLiked}
-              hasDday={item.hasDday}
-              dday={item.dday}
-            />
-          ))}
-        </div>
-      </div>
+    <BaseLayout header={<PageHeader title="찜 목록" onBack={handleBack} />} showBottomNav>
+      {!likeTradePostItems || likeTradePostItems.length === 0 ? (
+        <div className="py-4 text-center text-[var(--gray)]">게시물이 없습니다.</div>
+      ) : (
+        <>
+          <div className="px-4 pt-4 pb-[96px]">
+            <div className="grid grid-cols-2 gap-4">
+              {likeTradePostItems.map((item) => (
+                <TradePostCard
+                  key={item.postId}
+                  imageUrl={item.postImage}
+                  title={item.title}
+                  partner={item.partner}
+                  price={item.price}
+                  likeCount={item.postLikes}
+                  isLiked={true}
+                  hasDday={false}
+                  dday={0}
+                />
+              ))}
+            </div>
+          </div>
+          
+          {hasNext && (
+            <div className="mt-6 text-center">
+              <button
+                onClick={handleLoadMore}
+                disabled={isLoading}
+                className="px-6 py-2 bg-blue-500 text-white rounded-lg disabled:opacity-50"
+              >
+                {isLoading ? '로딩중...' : '더보기'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
     </BaseLayout>
   );
 } 

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -25,7 +25,6 @@ export const END_POINTS = {
     LOGIN: '/api/v1/auth/token/issue',
     REISSUE: '/api/v1/auth/reissue/token',
     FOLLOW: (userId: number) => `/api/v1/users/${userId}/follows`,
-    GET_FOLLOWS: '/api/v1/users/follows',
     SALES: '/api/v1/users/sales',
   },
   STORES: {
@@ -37,6 +36,8 @@ export const END_POINTS = {
   MYPAGE: {
     COIN: '/api/v1/users/coin',
     DATA_USAGE: '/api/v1/users/data',
+    FOLLOWINGS: '/api/v1/users/follows',
+    FOLLOWERS: '/api/v1/users/follows',
     RENTAL_HISTORY: '/api/v1/users/rentals',
     LIKE_STORE: '/api/v1/users/likes/stores',
     RESTOCK_ALARM: '/api/v1/users/restock',

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -38,6 +38,7 @@ export const END_POINTS = {
     DATA_USAGE: '/api/v1/users/data',
     FOLLOWINGS: '/api/v1/users/follows',
     FOLLOWERS: '/api/v1/users/follows',
+    LIKE_TRADE_POST: '/api/v1/users/likes/posts',
     RENTAL_HISTORY: '/api/v1/users/rentals',
     LIKE_STORE: '/api/v1/users/likes/stores',
     RESTOCK_ALARM: '/api/v1/users/restock',


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #158 

### 🔎 작업 내용
- [x] 나의 찜한 게시글 API 연동
• Feature-based Architecture 패턴에 따른 API/타입/쿼리/UI 계층 분리 및 페이지네이션 기능 추가
• Axios 인터셉터와 호환되는 API 응답 처리 로직 구현 및 TypeScript 타입 정의 개선
• 코드 리팩토링을 통한 중복 제거, 컴포넌트 최적화 및 타입 안전성 향상

### 📸 스크린샷
https://github.com/user-attachments/assets/f84f8451-ded9-4eab-9381-845d76b81b46

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
