### PR TITLE
Feat: [BADA-247] 나의 판매 내역 조회 API 연결, UI 수정

### DIFF
--- a/src/pages/mypage/sales-history/page/SalesHistoryPage.tsx
+++ b/src/pages/mypage/sales-history/page/SalesHistoryPage.tsx
@@ -63,9 +63,9 @@ const allPosts = [
 ];
 
 const tabList = [
-  { label: '전체', value: '전체' },
-  { label: '데이터', value: '데이터' },
-  { label: '쿠폰', value: '쿠폰' },
+  { id: '전체', label: '전체', value: '전체' },
+  { id: '데이터', label: '데이터', value: '데이터' },
+  { id: '쿠폰', label: '쿠폰', value: '쿠폰' },
 ];
 
 export default function SalesHistoryPage() {
@@ -79,7 +79,10 @@ export default function SalesHistoryPage() {
   );
 
   return (
-    <BaseLayout header={<PageHeader title="판매 내역" onBack={() => router.back()} />} showBottomNav>
+    <BaseLayout
+      header={<PageHeader title="판매 내역" onBack={() => router.back()} />}
+      showBottomNav
+    >
       <div className="w-full max-w-[428px]">
         <div className="flex flex-col items-center px-4 mt-4">
           <MyProfileCard name={profile.name} days={profile.days} avatarSrc={profile.avatarSrc} />

--- a/src/pages/mypage/sales-history/page/SalesHistoryPage.tsx
+++ b/src/pages/mypage/sales-history/page/SalesHistoryPage.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { useSalesQuery } from '@/entities/user/model/queries';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { FlatTab } from '@/shared/ui/FlatTab';
 import { PageHeader } from '@/shared/ui/Header';
@@ -20,48 +21,6 @@ const profile = {
   following: 7,
 };
 
-const allPosts = [
-  {
-    id: 1,
-    imageUrl: '/assets/trade-detail.jpg',
-    title: '쇼콜라 바니드라',
-    partner: '제휴처',
-    price: 2050,
-    likeCount: 5,
-    isCompleted: false,
-    isLiked: false,
-    hasDday: true,
-    dday: 5,
-    type: '전체',
-  },
-  {
-    id: 2,
-    imageUrl: '/assets/trade-detail.jpg',
-    title: '쇼콜라 바니드라',
-    partner: '제휴처',
-    price: 2050,
-    likeCount: 5,
-    isCompleted: false,
-    isLiked: false,
-    hasDday: true,
-    dday: 5,
-    type: '데이터',
-  },
-  {
-    id: 3,
-    imageUrl: '/assets/trade-detail.jpg',
-    title: '쇼콜라 바니드라',
-    partner: '제휴처',
-    price: 2050,
-    likeCount: 5,
-    isCompleted: false,
-    isLiked: false,
-    hasDday: true,
-    dday: 5,
-    type: '쿠폰',
-  },
-];
-
 const tabList = [
   { id: '전체', label: '전체', value: '전체' },
   { id: '데이터', label: '데이터', value: '데이터' },
@@ -70,13 +29,42 @@ const tabList = [
 
 export default function SalesHistoryPage() {
   const router = useRouter();
-  const [tab, setTab] = useState('전체');
+  const [tab, setTab] = useState<'전체' | '데이터' | '쿠폰'>('전체');
   const [isCompleted, setIsCompleted] = useState(false);
+  const observerRef = useRef<HTMLDivElement>(null);
 
-  const filteredPosts = allPosts.filter(
-    (item) =>
-      item.hasDday && (tab === '전체' || item.type === tab) && item.isCompleted === isCompleted,
+  const postCategory = tab === '전체' ? undefined : tab === '데이터' ? 'DATA' : 'GIFTICON';
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, error } =
+    useSalesQuery(
+      undefined, // userId 없음 (현재 로그인한 사용자)
+      postCategory,
+      isCompleted,
+      undefined,
+      30,
+    );
+
+  const handleIntersection = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
   );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleIntersection, {
+      threshold: 0.1,
+    });
+
+    if (observerRef.current) {
+      observer.observe(observerRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [handleIntersection]);
 
   return (
     <BaseLayout
@@ -84,7 +72,7 @@ export default function SalesHistoryPage() {
       showBottomNav
     >
       <div className="w-full max-w-[428px]">
-        <div className="flex flex-col items-center px-4 mt-4">
+        <div className="flex flex-col items-center mt-4">
           <MyProfileCard name={profile.name} days={profile.days} avatarSrc={profile.avatarSrc} />
 
           <div className="flex justify-between items-center w-full bg-[var(--main-1)] rounded-xl px-4 py-3 mt-4 mb-6">
@@ -115,7 +103,7 @@ export default function SalesHistoryPage() {
           </div>
         </div>
 
-        <div className="px-4">
+        <div>
           <FlatTab items={tabList} value={tab} onValueChange={setTab} />
         </div>
 
@@ -127,11 +115,52 @@ export default function SalesHistoryPage() {
           />
         </div>
 
-        <div className="px-4 pb-[96px]">
-          <div className="grid grid-cols-2 gap-4">
-            {filteredPosts.map((item) => (
-              <TradePostCard key={item.id} {...item} />
-            ))}
+        <div className="pb-[96px]">
+          {/* 로딩 상태 */}
+          {isLoading && (
+            <div className="text-center py-8">
+              <p>판매 내역을 불러오는 중...</p>
+            </div>
+          )}
+
+          {/* 에러 상태 */}
+          {isError && (
+            <div className="text-center py-8 text-[var(--red)]">
+              <p>판매 내역을 불러오는데 실패했습니다.</p>
+              <p className="text-sm mt-2">{error?.message}</p>
+            </div>
+          )}
+
+          {/* 데이터가 없는 경우 */}
+          {!isLoading &&
+            !isError &&
+            (!data?.pages ||
+              data.pages.length === 0 ||
+              data.pages.every((page) => page.content?.item.length === 0)) && (
+              <div className="text-center py-8 text-[var(--gray-mid)]">
+                <p>판매 내역이 없습니다.</p>
+              </div>
+            )}
+
+          {/* 데이터 표시 */}
+          {data?.pages.map((page, i) => (
+            <div key={i} className="grid grid-cols-2 gap-4">
+              {page.content?.item.map((item) => (
+                <TradePostCard
+                  key={item.postId}
+                  imageUrl={item.postImage || '/assets/trade-detail.jpg'}
+                  title={item.title}
+                  partner={item.partner || '제휴처'}
+                  price={item.price}
+                  likeCount={item.postLikes}
+                  isCompleted={item.isSold}
+                />
+              ))}
+            </div>
+          ))}
+
+          <div ref={observerRef} className="h-12">
+            {isFetchingNextPage && <p className="text-center">불러오는 중...</p>}
           </div>
         </div>
       </div>

--- a/src/shared/ui/Skeleton/Skeleton.tsx
+++ b/src/shared/ui/Skeleton/Skeleton.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/shared/lib/cn';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-md bg-[var(--main-1)] [animation-duration:2s]',
+        className,
+      )}
+    />
+  );
+}

--- a/src/shared/ui/Skeleton/TradePostCardSkeleton.tsx
+++ b/src/shared/ui/Skeleton/TradePostCardSkeleton.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from './Skeleton';
+
+export function TradePostCardSkeleton() {
+  return (
+    <div className="flex flex-col space-y-2">
+      {/* 이미지 스켈레톤 */}
+      <Skeleton className="aspect-square w-full rounded-lg" />
+
+      {/* 제목 스켈레톤 */}
+      <Skeleton className="h-4 w-3/4" />
+
+      {/* 파트너 스켈레톤 */}
+      <Skeleton className="h-3 w-1/2" />
+
+      {/* 가격 스켈레톤 */}
+      <Skeleton className="h-5 w-2/3" />
+
+      {/* 좋아요 수 스켈레톤 */}
+      <Skeleton className="h-3 w-1/3" />
+    </div>
+  );
+}

--- a/src/shared/ui/Switch/Switch.tsx
+++ b/src/shared/ui/Switch/Switch.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
 
-import { Root as SwitchRoot, Thumb as SwitchThumb } from '@radix-ui/react-switch';
+import { Root as SwitchRoot } from '@radix-ui/react-switch';
 
 import { cn } from '@/shared/lib/cn';
 
@@ -37,7 +37,7 @@ export function Switch({ checked, onCheckedChange, labels, ...props }: CustomSwi
         )}
 
         {hasLabels && (
-          <div className="relative z-20 flex w-full h-full text-sm font-regular text-white">
+          <div className="relative z-20 flex w-full h-full font-label-regular text-[var(--white)]">
             <span
               className={cn(
                 'flex-1 flex items-center justify-center transition-opacity',
@@ -56,16 +56,6 @@ export function Switch({ checked, onCheckedChange, labels, ...props }: CustomSwi
             </span>
           </div>
         )}
-
-        <SwitchThumb
-          className={cn(
-            'absolute top-[2px] left-[2px] h-[22px] w-[22px] rounded-full bg-[var(--main-1)] shadow transition-all',
-            checked && hasLabels && 'translate-x-[88px]',
-            !checked && hasLabels && 'translate-x-0',
-            checked && !hasLabels && 'translate-x-[24px]',
-            !checked && !hasLabels && 'translate-x-0',
-          )}
-        />
       </SwitchRoot>
     </div>
   );


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #156

### 🔎 작업 내용

- [x] 판매 내역 조회 API 연동 및 무한 스크롤 구현
- [x] 탭 별 필터링 기능 (전체/데이터/쿠폰) 구현
- [x] 판매 상태 필터링 (판매중/판매완료) 구현
- [x] 스켈레톤 로딩 UI 구현 및 최적화
  - [x] 스켈레톤 로딩 구현 (200ms 임계값으로 깜빡임 방지)
- [x] 에러 상태 및 빈 데이터 상태 처리
- [x] TradePostCard 클릭 시 카테고리 별 상세 페이지 이동 기능
- [x] API 응답 구조 개선 (getSales)

### 📸 스크린샷

https://github.com/user-attachments/assets/e67618bb-972e-48f8-8342-1763efef914a

### :loudspeaker: 전달사항

- useSalesQuery를 무한 스크롤용으로 리팩토링
- 무한 스크롤: IntersectionObserver API 사용
- 상태 관리: React Query의 useInfiniteQuery 활용
- 로딩 최적화: 200ms 임계값으로 스켈레톤 표시 제어

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
