### PR TITLE
Feat: [BADA-266] 실시간 인기 검색어 API 연동

### DIFF
--- a/src/entities/trade-post/api/apis.ts
+++ b/src/entities/trade-post/api/apis.ts
@@ -8,6 +8,7 @@ import type {
   LikeContent,
   ReportRequest,
   ReportResponse,
+  SearchTrendsContent,
 } from '@/entities/trade-post/lib/types';
 
 // 게시물 목록 조회
@@ -53,6 +54,7 @@ export const deleteTradePostLike = async (postId: number): Promise<LikeContent> 
   return content;
 };
 
+// 게시물 신고
 export const reportTradePost = async (
   postId: number,
   reportData: ReportRequest,
@@ -62,4 +64,10 @@ export const reportTradePost = async (
     reportData,
   );
   return content;
+};
+
+// 거래 실시간 인기 검색어 조회
+export const getSearchTrends = async (): Promise<string[]> => {
+  const response: SearchTrendsContent = await axiosInstance.get(END_POINTS.TRADES.SEARCH_TRENDS);
+  return response.trendingTopics ?? [];
 };

--- a/src/entities/trade-post/lib/types.ts
+++ b/src/entities/trade-post/lib/types.ts
@@ -102,3 +102,7 @@ export interface ReportRequest {
 export interface ReportResponse {
   reportId: number;
 }
+
+export interface SearchTrendsContent {
+  trendingTopics: string[];
+}

--- a/src/pages/trade/search-post/model/queries.ts
+++ b/src/pages/trade/search-post/model/queries.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { getSearchTrends } from '@/entities/trade-post/api/apis';
 import { getSearchTradePosts } from '@/pages/trade/search-post/api/apis';
 
 import type { BasePost } from '@/entities/trade-post/lib/types';
@@ -23,4 +24,25 @@ export const useSearchTradePostsQuery = (keyword: string) => {
     gcTime: 5 * 60 * 1000,
     staleTime: 5 * 60 * 1000,
   });
+};
+
+// 실시간 인기 검색어 조회 쿼리
+export const useSearchTrendsQuery = () => {
+  const {
+    data: searchTrends,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['search-trends'],
+    queryFn: getSearchTrends,
+    gcTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  });
+
+  return {
+    searchTrends: searchTrends ?? [],
+    isLoading,
+    error,
+  };
 };

--- a/src/pages/trade/search-post/model/useRecentSearchHooks.ts
+++ b/src/pages/trade/search-post/model/useRecentSearchHooks.ts
@@ -11,9 +11,26 @@ import {
 
 export const useRecentSearchHooks = () => {
   const [keywords, setKeywords] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    setKeywords(getRecentKeywords());
+    // localStorage에서 데이터를 가져오는 동안 로딩 상태 유지
+    const loadKeywords = () => {
+      try {
+        const recentKeywords = getRecentKeywords();
+        setKeywords(recentKeywords);
+      } catch (error) {
+        console.error('Failed to load recent keywords:', error);
+        setKeywords([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    // 약간의 지연을 주어 스켈레톤 UI가 보이도록 함
+    const timer = setTimeout(loadKeywords, 90);
+
+    return () => clearTimeout(timer);
   }, []);
 
   const add = useCallback((keyword: string) => {
@@ -31,6 +48,7 @@ export const useRecentSearchHooks = () => {
 
   return {
     keywords,
+    isLoading,
     add,
     remove,
     clear,

--- a/src/pages/trade/search-post/page/SearchTradePage.tsx
+++ b/src/pages/trade/search-post/page/SearchTradePage.tsx
@@ -23,9 +23,13 @@ export function TradeSearchPage() {
 
   const { data: posts, isLoading, isError } = useSearchTradePostsQuery(debouncedSearch);
 
-  const { keywords: recentKeywords, add, remove, clear } = useRecentSearchHooks();
-
-  const hotKeywords = ['공유 데이터', '영화관 할인쿠폰', '데이터 1GB', '스타벅스 아메리카노'];
+  const {
+    keywords: recentKeywords,
+    isLoading: isRecentKeywordsLoading,
+    add,
+    remove,
+    clear,
+  } = useRecentSearchHooks();
 
   const handleBack = useCallback(() => router.back(), [router]);
 
@@ -51,8 +55,9 @@ export function TradeSearchPage() {
         onDeleteKeyword={remove}
         onDeleteAll={clear}
         onClickKeyword={handleSearchSubmit}
+        isLoading={isRecentKeywordsLoading}
       />
-      <SearchHotKeywords keywords={hotKeywords} onKeywordClick={handleSearchSubmit} />
+      <SearchHotKeywords onKeywordClick={handleSearchSubmit} />
       <SearchResult
         search={debouncedSearch}
         posts={posts as DataPost[] | GifticonPost[]}

--- a/src/pages/trade/search-post/page/SearchTradePage.tsx
+++ b/src/pages/trade/search-post/page/SearchTradePage.tsx
@@ -52,7 +52,7 @@ export function TradeSearchPage() {
         onDeleteAll={clear}
         onClickKeyword={handleSearchSubmit}
       />
-      <SearchHotKeywords keywords={hotKeywords} />
+      <SearchHotKeywords keywords={hotKeywords} onKeywordClick={handleSearchSubmit} />
       <SearchResult
         search={debouncedSearch}
         posts={posts as DataPost[] | GifticonPost[]}

--- a/src/pages/trade/search-post/ui/SearchHotKeywords.tsx
+++ b/src/pages/trade/search-post/ui/SearchHotKeywords.tsx
@@ -1,33 +1,65 @@
 import { Flame } from 'lucide-react';
 
+import { useSearchTrendsQuery } from '@/pages/trade/search-post/model/queries';
 import { Badge } from '@/shared/ui/Badge';
 
 interface SearchHotKeywordsProps {
-  keywords: string[];
   onKeywordClick?: (keyword: string) => void;
 }
 
-export const SearchHotKeywords = ({ keywords, onKeywordClick }: SearchHotKeywordsProps) => {
+export const SearchHotKeywords = ({ onKeywordClick }: SearchHotKeywordsProps) => {
+  const { searchTrends, isLoading, error } = useSearchTrendsQuery();
+
   const handleKeywordClick = (keyword: string) => {
     onKeywordClick?.(keyword);
   };
 
+  // 로딩 상태 처리
+  if (isLoading) {
+    return (
+      <section className="mb-6">
+        <div className="flex items-center gap-1 mb-2 font-body-medium">
+          <Flame className="w-5 h-5 text-orange-500" />
+          <span className="text-[var(--black)] font-body-semibold">실시간 hot 검색어</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-6 w-16 animate-pulse rounded-full bg-[var(--gray-light)]"
+            />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  // 에러 상태 처리
+  if (error) {
+    return null; // 에러 시 컴포넌트를 숨김
+  }
+
+  // 데이터가 없을 때 처리
+  if (!searchTrends || searchTrends.length === 0) {
+    return null;
+  }
+
   return (
     <section className="mb-6">
-      <div className="flex items-center gap-1 mb-2 text-[1.25rem] font-medium">
-        <Flame className="w-4 h-4 text-orange-500" />
-        <span className="text-black font-semibold">실시간 hot 검색어</span>
+      <div className="flex items-center gap-1 mb-2 font-body-medium">
+        <Flame className="w-5 h-5 text-orange-500" />
+        <span className="text-[var(--black)] font-body-semibold">실시간 hot 검색어</span>
       </div>
       <div className="flex flex-wrap gap-2">
-        {keywords.map((keyword, index) => (
+        {searchTrends.slice(0, 5).map((keyword: string, index: number) => (
           <Badge
-            key={index}
+            key={`${keyword}-${index}`}
             size="xs"
             color="grayLight"
             onClick={() => handleKeywordClick(keyword)}
-            className="cursor-pointer hover:bg-gray-200 transition-colors"
+            className="cursor-pointer hover:brightness-95 transition-colors"
           >
-            {keyword}
+            #{keyword}
           </Badge>
         ))}
       </div>

--- a/src/pages/trade/search-post/ui/SearchHotKeywords.tsx
+++ b/src/pages/trade/search-post/ui/SearchHotKeywords.tsx
@@ -36,12 +36,32 @@ export const SearchHotKeywords = ({ onKeywordClick }: SearchHotKeywordsProps) =>
 
   // 에러 상태 처리
   if (error) {
-    return null; // 에러 시 컴포넌트를 숨김
+    return (
+      <section className="mb-6">
+        <div className="flex items-center gap-1 mb-2 font-body-medium">
+          <Flame className="w-5 h-5 text-orange-500" />
+          <span className="text-[var(--black)] font-body-semibold">실시간 hot 검색어</span>
+        </div>
+        <div className="font-caption-regular text-[var(--gray-dark)] text-center py-2">
+          인기 검색어를 불러오는 중 문제가 발생했습니다.
+        </div>
+      </section>
+    );
   }
 
   // 데이터가 없을 때 처리
   if (!searchTrends || searchTrends.length === 0) {
-    return null;
+    return (
+      <section className="mb-6">
+        <div className="flex items-center gap-1 mb-2 font-body-medium">
+          <Flame className="w-5 h-5 text-orange-500" />
+          <span className="text-[var(--black)] font-body-semibold">실시간 hot 검색어</span>
+        </div>
+        <div className="font-caption-regular text-[var(--gray-dark)] text-center py-2">
+          현재 인기 검색어가 없습니다.
+        </div>
+      </section>
+    );
   }
 
   return (

--- a/src/pages/trade/search-post/ui/SearchHotKeywords.tsx
+++ b/src/pages/trade/search-post/ui/SearchHotKeywords.tsx
@@ -4,9 +4,14 @@ import { Badge } from '@/shared/ui/Badge';
 
 interface SearchHotKeywordsProps {
   keywords: string[];
+  onKeywordClick?: (keyword: string) => void;
 }
 
-export const SearchHotKeywords = ({ keywords }: SearchHotKeywordsProps) => {
+export const SearchHotKeywords = ({ keywords, onKeywordClick }: SearchHotKeywordsProps) => {
+  const handleKeywordClick = (keyword: string) => {
+    onKeywordClick?.(keyword);
+  };
+
   return (
     <section className="mb-6">
       <div className="flex items-center gap-1 mb-2 text-[1.25rem] font-medium">
@@ -15,7 +20,13 @@ export const SearchHotKeywords = ({ keywords }: SearchHotKeywordsProps) => {
       </div>
       <div className="flex flex-wrap gap-2">
         {keywords.map((keyword, index) => (
-          <Badge key={index} size="xs" color="grayLight">
+          <Badge
+            key={index}
+            size="xs"
+            color="grayLight"
+            onClick={() => handleKeywordClick(keyword)}
+            className="cursor-pointer hover:bg-gray-200 transition-colors"
+          >
             {keyword}
           </Badge>
         ))}

--- a/src/pages/trade/search-post/ui/SearchRecentKeywords.tsx
+++ b/src/pages/trade/search-post/ui/SearchRecentKeywords.tsx
@@ -16,10 +16,10 @@ export const SearchRecentKeywords = ({
   isLoading = false,
 }: SearchRecentKeywordsProps) => {
   return (
-    <section className="mb-6">
+    <section className="mb-8">
       <div className="flex justify-between items-center mb-2 font-body-medium">
         <span className="text-[var(--black)] font-body-semibold">최근 검색어</span>
-        <button className="text-xs text-[var(--gray-mid)]" onClick={onDeleteAll}>
+        <button className="font-small-regular text-[var(--gray-mid)]" onClick={onDeleteAll}>
           전체 삭제
         </button>
       </div>

--- a/src/pages/trade/search-post/ui/SearchRecentKeywords.tsx
+++ b/src/pages/trade/search-post/ui/SearchRecentKeywords.tsx
@@ -5,6 +5,7 @@ interface SearchRecentKeywordsProps {
   onDeleteKeyword?: (keyword: string) => void;
   onDeleteAll?: () => void;
   onClickKeyword?: (keyword: string) => void;
+  isLoading?: boolean;
 }
 
 export const SearchRecentKeywords = ({
@@ -12,24 +13,29 @@ export const SearchRecentKeywords = ({
   onDeleteKeyword,
   onDeleteAll,
   onClickKeyword,
+  isLoading = false,
 }: SearchRecentKeywordsProps) => {
   return (
     <section className="mb-6">
-      <div className="flex justify-between items-center mb-2 text-[1.25rem] text-muted-foreground">
-        <span className="text-black font-semibold">최근 검색어</span>
-        <button className="text-xs text-gray-400" onClick={onDeleteAll}>
+      <div className="flex justify-between items-center mb-2 font-body-medium">
+        <span className="text-[var(--black)] font-body-semibold">최근 검색어</span>
+        <button className="text-xs text-[var(--gray-mid)]" onClick={onDeleteAll}>
           전체 삭제
         </button>
       </div>
       <div className="flex flex-wrap gap-2">
-        {keywords.map((keyword, index) => (
-          <RecentSearchBadge
-            key={index}
-            label={keyword}
-            onDelete={onDeleteKeyword || (() => {})}
-            onClick={onClickKeyword}
-          />
-        ))}
+        {isLoading
+          ? Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="h-6 w-20 animate-pulse rounded-full bg-[var(--main-1)]" />
+            ))
+          : keywords.map((keyword, index) => (
+              <RecentSearchBadge
+                key={index}
+                label={keyword}
+                onDelete={onDeleteKeyword || (() => {})}
+                onClick={onClickKeyword}
+              />
+            ))}
       </div>
     </section>
   );

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -11,6 +11,7 @@ export const END_POINTS = {
     UPDATE_GIFTICON: (postId: number) => `/api/v1/trades/posts/gifticon/${postId}`,
     DEADLINE: '/api/v1/trades/posts/deadline',
     SEARCH: (keyword: string) => `/api/v1/trades/posts?query=${keyword}`,
+    SEARCH_TRENDS: '/api/v1/trades/search/trending',
     REGISTER_DATA: '/api/v1/trades/posts/data',
     REGISTER_GIFTICON: '/api/v1/trades/posts/gifticon',
     USER_POST: (userId: number) => `/api/v1/trades/posts/${userId}`,

--- a/src/widgets/trade/post-detail/ui/TradeDetailProductSection.tsx
+++ b/src/widgets/trade/post-detail/ui/TradeDetailProductSection.tsx
@@ -61,7 +61,7 @@ export const TradeDetailProductSection = ({
       <div className="flex justify-between items-center mb-2">
         <span className="font-label-medium text-black">가격</span>
         <span className="font-label-semibold text-[var(--main-5)]">
-          {price?.toLocaleString()}원
+          {price?.toLocaleString()} 원
         </span>
       </div>
 
@@ -77,7 +77,7 @@ export const TradeDetailProductSection = ({
       {postType === 'DATA' && capacity !== undefined && (
         <div className="flex justify-between items-center mb-2">
           <span className="font-label-medium text-black">데이터 용량</span>
-          <span className="font-label-semibold text-[var(--gray-dark)]">{capacity}GB</span>
+          <span className="font-label-semibold text-[var(--gray-dark)]">{capacity} MB</span>
         </div>
       )}
 


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #171

### 🔎 작업 내용

- [x] API 엔드포인트, response 타입 정의
- [x] API 함수 구현: `getSearchTrends`
- [x] react Query 훅 생성: `useSearchTrendsQuery`
- [x] `SearchHotKeywords`에 실시간 API 연동
  - 로딩 상태 처리: 스켈레톤 UI 구현
  - 에러 처리: 에러 시 컴포넌트 숨김
  - 빈 데이터 처리: 데이터 없을 시 컴포넌트 숨김
- [x] `SearchRecentKeywords`에 로딩 상태 지원
  - 로딩 상태 추가: isLoading 상태관리
  - 에러 처리: localStorage 접근 실패 시 안전하게 처리
  - 90ms 지연으로 자연스럽게 보이도록 함
  - 실시간 검색어와 최근 검색어 모두 스켈레톤 UI 제공함으로서 일관된 로딩 경험 제공

### 📸 스크린샷
<img width="200" alt="image" src="https://github.com/user-attachments/assets/41e998bc-d8bb-4816-9d7d-b674e30f5d86" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/75a5fda3-3b6f-47e1-87e2-b01a6a3838ab" />

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
