### PR TITLE
Feat: [BADA-299] 대여 리뷰 수정/삭제 API 연동 및 기능 추가

### DIFF
--- a/src/features/rental/store/register-review/_client/ReviewRegisterPageContent.tsx
+++ b/src/features/rental/store/register-review/_client/ReviewRegisterPageContent.tsx
@@ -1,12 +1,22 @@
 'use client';
-
 import { useSearchParams } from 'next/navigation';
 
+import { useReviewDetailQuery } from '@/features/rental/store/register-review/model/queries';
 import ReviewRegisterForm from '@/features/rental/store/register-review/ui/ReviewRegisterForm';
 
 export default function ReviewRegisterPageContent() {
   const searchParams = useSearchParams();
+  const reviewId = Number(searchParams?.get('reviewId'));
+  const mode = (searchParams?.get('mode') as 'register' | 'edit') || 'register';
   const reservationId = Number(searchParams?.get('reservationId'));
 
-  return <ReviewRegisterForm reservationId={reservationId} />;
+  const { data: reviewDetail } = useReviewDetailQuery(reviewId);
+
+  return (
+    <ReviewRegisterForm
+      reservationId={reservationId}
+      mode={mode}
+      reviewDetail={mode === 'edit' ? reviewDetail : undefined}
+    />
+  );
 }

--- a/src/features/rental/store/register-review/api/apis.ts
+++ b/src/features/rental/store/register-review/api/apis.ts
@@ -60,6 +60,6 @@ export const updateReview = async (reviewId: number, data: UpdateReviewRequest) 
   return await axiosInstance.patch(`${END_POINTS.STORES.REVIEW}/${reviewId}`, formData);
 };
 
-export const deleteReview = async (reviewId: number) => {
-  return await axiosInstance.delete(`${END_POINTS.STORES.REVIEW}/${reviewId}`);
+export const deleteReview = async (reviewId: number): Promise<void> => {
+  await axiosInstance.delete(`${END_POINTS.STORES.REVIEW}/${reviewId}`);
 };

--- a/src/features/rental/store/register-review/api/apis.ts
+++ b/src/features/rental/store/register-review/api/apis.ts
@@ -5,20 +5,24 @@ import type {
   PostReviewRequest,
   QuickReply,
   ReservationDetails,
+  ReviewDetailResponse,
+  UpdateReviewRequest,
 } from '@/features/rental/store/register-review/lib/types';
 
-// 퀵 리플라이 목록 조회
 export const getQuickReplies = async (): Promise<QuickReply[]> => {
   const content: QuickReply[] = await axiosInstance.get(END_POINTS.STORES.REVIEW_QUICK_REPLIES);
   return content;
 };
 
-// 특정 예약의 상세 정보 조회(가맹점, 대여 기기, 방문 횟수)
 export const getReservationDetails = async (reservationId: number): Promise<ReservationDetails> => {
   const content: ReservationDetails = await axiosInstance.get(
     END_POINTS.RENTAL.RESERVATION_DETAILS(reservationId),
   );
   return content;
+};
+
+export const getReviewDetail = async (reviewId: number): Promise<ReviewDetailResponse> => {
+  return await axiosInstance.get(`${END_POINTS.STORES.REVIEW}/${reviewId}`);
 };
 
 export const postReview = async (
@@ -45,4 +49,17 @@ export const postReview = async (
   );
 
   return response;
+};
+
+export const updateReview = async (reviewId: number, data: UpdateReviewRequest) => {
+  const formData = new FormData();
+  formData.append('comment', data.comment);
+  formData.append('rating', data.rating.toString());
+  data.quickReplyIds.forEach((id) => formData.append('quickReplyIds', id.toString()));
+  if (data.file) formData.append('file', data.file);
+  return await axiosInstance.patch(`${END_POINTS.STORES.REVIEW}/${reviewId}`, formData);
+};
+
+export const deleteReview = async (reviewId: number) => {
+  return await axiosInstance.delete(`${END_POINTS.STORES.REVIEW}/${reviewId}`);
 };

--- a/src/features/rental/store/register-review/lib/types.ts
+++ b/src/features/rental/store/register-review/lib/types.ts
@@ -3,18 +3,37 @@ export interface QuickReply {
   quickReplyName: string;
 }
 
-export interface ReservationDevice {
+export interface ReviewDevice {
   deviceName: string;
   dataCapacity: number;
   price: number;
   count: number;
 }
 
+export interface ReviewDetailResponse {
+  reviewId: number;
+  writerId: number;
+  reservationId: number;
+  rating: number;
+  comment: string;
+  reviewImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  quickReplyIds: number[];
+  showRentalResponses: {
+    storeId: number;
+    storeImageUrl: string;
+    storeName: string;
+    showReservedDeviceResponses: ReviewDevice[];
+    countOfVisit: number;
+  };
+}
+
 export interface ReservationDetails {
   storeId: number;
   storeImageUrl: string;
   storeName: string;
-  showReservedDeviceResponses: ReservationDevice[];
+  showReservedDeviceResponses: ReviewDevice[];
   countOfVisit: number;
 }
 
@@ -23,7 +42,14 @@ export interface PostReviewRequest {
   quickReplyIds: number[];
   comment: string;
   rating: number;
-  file?: File | undefined;
+  file?: File;
+}
+
+export interface UpdateReviewRequest {
+  quickReplyIds: number[];
+  comment: string;
+  rating: number;
+  file?: File;
 }
 
 export interface PostReviewResponse {
@@ -34,5 +60,5 @@ export interface ReviewFormState {
   rating: number;
   selectedQuickReplies: number[];
   comment: string;
-  image: File | undefined;
+  image: string | File | undefined;
 }

--- a/src/features/rental/store/register-review/model/mutations.ts
+++ b/src/features/rental/store/register-review/model/mutations.ts
@@ -5,12 +5,16 @@ import {
   postReview,
   updateReview,
 } from '@/features/rental/store/register-review/api/apis';
+import { ErrorMessageMap } from '@/shared/config/errorCodes';
+import { HTTPError } from '@/shared/lib/HTTPError';
+import { makeToast } from '@/shared/lib/makeToast';
 import { queryClient } from '@/shared/lib/queryClient';
 
 import type {
   PostReviewRequest,
   UpdateReviewRequest,
 } from '@/features/rental/store/register-review/lib/types';
+import type { ErrorCode } from '@/shared/config/errorCodes';
 
 export const usePostReviewMutation = () => {
   return useMutation({
@@ -36,5 +40,11 @@ export const useDeleteReviewMutation = () => {
   return useMutation({
     mutationFn: deleteReview,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['review'] }),
+    onError: (error) => {
+      if (error instanceof HTTPError) {
+        const errorMessage = ErrorMessageMap[error.code as ErrorCode] ?? error.message;
+        makeToast(errorMessage, 'warning');
+      }
+    },
   });
 };

--- a/src/features/rental/store/register-review/model/mutations.ts
+++ b/src/features/rental/store/register-review/model/mutations.ts
@@ -25,6 +25,7 @@ export const usePostReviewMutation = () => {
       reservationId: number;
       reviewData: PostReviewRequest;
     }) => postReview(reservationId, reviewData),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['review'] }),
   });
 };
 

--- a/src/features/rental/store/register-review/model/mutations.ts
+++ b/src/features/rental/store/register-review/model/mutations.ts
@@ -1,19 +1,40 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { postReview } from '@/features/rental/store/register-review/api/apis';
+import {
+  deleteReview,
+  postReview,
+  updateReview,
+} from '@/features/rental/store/register-review/api/apis';
+import { queryClient } from '@/shared/lib/queryClient';
 
 import type {
   PostReviewRequest,
-  PostReviewResponse,
+  UpdateReviewRequest,
 } from '@/features/rental/store/register-review/lib/types';
 
-interface PostReviewVariables {
-  reservationId: number;
-  reviewData: Omit<PostReviewRequest, 'reservationId'>;
-}
-
 export const usePostReviewMutation = () => {
-  return useMutation<PostReviewResponse, Error, PostReviewVariables>({
-    mutationFn: ({ reservationId, reviewData }) => postReview(reservationId, reviewData),
+  return useMutation({
+    mutationFn: ({
+      reservationId,
+      reviewData,
+    }: {
+      reservationId: number;
+      reviewData: PostReviewRequest;
+    }) => postReview(reservationId, reviewData),
+  });
+};
+
+export const useUpdateReviewMutation = () => {
+  return useMutation({
+    mutationFn: ({ reviewId, reviewData }: { reviewId: number; reviewData: UpdateReviewRequest }) =>
+      updateReview(reviewId, reviewData),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['review'] }),
+  });
+};
+
+export const useDeleteReviewMutation = () => {
+  return useMutation({
+    mutationFn: deleteReview,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['review'] }),
   });
 };

--- a/src/features/rental/store/register-review/model/queries.ts
+++ b/src/features/rental/store/register-review/model/queries.ts
@@ -3,7 +3,16 @@ import { useQuery } from '@tanstack/react-query';
 import {
   getQuickReplies,
   getReservationDetails,
+  getReviewDetail,
 } from '@/features/rental/store/register-review/api/apis';
+
+export const useReviewDetailQuery = (reviewId: number) => {
+  return useQuery({
+    queryKey: ['review', reviewId],
+    queryFn: () => getReviewDetail(reviewId),
+    enabled: !!reviewId,
+  });
+};
 
 export const registerReviewQueryKeys = {
   all: ['registerReview'] as const,

--- a/src/features/rental/store/register-review/model/queries.ts
+++ b/src/features/rental/store/register-review/model/queries.ts
@@ -6,22 +6,21 @@ import {
   getReviewDetail,
 } from '@/features/rental/store/register-review/api/apis';
 
-export const useReviewDetailQuery = (reviewId: number) => {
-  return useQuery({
-    queryKey: ['review', reviewId],
-    queryFn: () => getReviewDetail(reviewId),
-    enabled: !!reviewId,
-  });
-};
-
 export const registerReviewQueryKeys = {
   all: ['registerReview'] as const,
   quickReplies: () => [...registerReviewQueryKeys.all, 'quickReplies'] as const,
-  reservationDetails: (reservationId: number) => [
-    ...registerReviewQueryKeys.all,
-    'reservationDetails',
-    reservationId,
-  ],
+  reservationDetails: (reservationId: number) =>
+    [...registerReviewQueryKeys.all, 'reservationDetails', reservationId] as const,
+  reviewDetail: (reviewId: number) =>
+    [...registerReviewQueryKeys.all, 'reviewDetail', reviewId] as const,
+};
+
+export const useReviewDetailQuery = (reviewId: number) => {
+  return useQuery({
+    queryKey: registerReviewQueryKeys.reviewDetail(reviewId),
+    queryFn: () => getReviewDetail(reviewId),
+    enabled: !!reviewId && reviewId > 0,
+  });
 };
 
 export const useQuickReplies = () => {

--- a/src/features/rental/store/register-review/model/reviewFormReducer.ts
+++ b/src/features/rental/store/register-review/model/reviewFormReducer.ts
@@ -4,7 +4,7 @@ type ReviewFormAction =
   | { type: 'SET_RATING'; payload: number }
   | { type: 'TOGGLE_QUICK_REPLY'; payload: number }
   | { type: 'SET_COMMENT'; payload: string }
-  | { type: 'SET_IMAGE'; payload: File | undefined }
+  | { type: 'SET_IMAGE'; payload: string | File | undefined }
   | { type: 'RESET' };
 
 export const initialState: ReviewFormState = {

--- a/src/features/rental/store/register-review/ui/ImageUploadSection.tsx
+++ b/src/features/rental/store/register-review/ui/ImageUploadSection.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { Upload } from 'lucide-react';
 
 interface ImageUploadSectionProps {
-  selectedImage: File | undefined;
+  selectedImage: File | string | undefined;
   onImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -16,13 +16,18 @@ export default function ImageUploadSection({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    if (selectedImage) {
+    if (!selectedImage) {
+      setPreviewUrl(null);
+      return;
+    }
+
+    if (typeof selectedImage === 'string') {
+      setPreviewUrl(selectedImage);
+    } else {
       const url = URL.createObjectURL(selectedImage);
       setPreviewUrl(url);
 
       return () => URL.revokeObjectURL(url);
-    } else {
-      setPreviewUrl(null);
     }
   }, [selectedImage]);
 

--- a/src/features/rental/store/register-review/ui/ReservationDetailsSection.tsx
+++ b/src/features/rental/store/register-review/ui/ReservationDetailsSection.tsx
@@ -20,7 +20,8 @@ export default function ReservationDetailsSection({
           <div className="w-12 h-12 bg-[var(--gray)] rounded-lg relative overflow-hidden">
             <Image
               src={reservationDetails.storeImageUrl}
-              fill
+              width={48}
+              height={48}
               className="object-cover"
               alt="가맹점이미지"
             />

--- a/src/features/rental/store/register-review/ui/ReviewRegisterForm.tsx
+++ b/src/features/rental/store/register-review/ui/ReviewRegisterForm.tsx
@@ -118,7 +118,6 @@ export default function ReviewRegisterForm({
           },
           onError: (error) => {
             console.error('리뷰 등록 실패: ', error);
-            makeToast('리뷰 등록에 실패했습니다.', 'warning');
           },
         },
       );

--- a/src/features/rental/store/register-review/ui/ReviewRegisterForm.tsx
+++ b/src/features/rental/store/register-review/ui/ReviewRegisterForm.tsx
@@ -1,9 +1,11 @@
-import type React from 'react';
-import { useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { usePostReviewMutation } from '@/features/rental/store/register-review/model/mutations';
+import {
+  usePostReviewMutation,
+  useUpdateReviewMutation,
+} from '@/features/rental/store/register-review/model/mutations';
 import {
   useQuickReplies,
   useReservationDetails,
@@ -21,18 +23,44 @@ import { PATH } from '@/shared/config/path';
 import { makeToast } from '@/shared/lib/makeToast';
 import { RegisterButton } from '@/shared/ui/RegisterButton';
 
+import type { ReviewDetailResponse } from '@/features/rental/store/register-review/lib/types';
+
 interface ReviewRegisterFormProps {
   reservationId: number;
+  mode: 'register' | 'edit';
+  reviewDetail?: ReviewDetailResponse;
 }
-export default function ReviewRegisterForm({ reservationId }: ReviewRegisterFormProps) {
+
+export default function ReviewRegisterForm({
+  reservationId,
+  mode,
+  reviewDetail,
+}: ReviewRegisterFormProps) {
   const router = useRouter();
+  const resolvedReservationId =
+    mode === 'edit' && reviewDetail ? reviewDetail.reservationId : reservationId;
+
   const [state, dispatch] = useReducer(reviewFormReducer, initialState);
 
   const { data: quickRepliesData, isLoading: isQuickRepliesLoading } = useQuickReplies();
   const { data: reservationDetailsData, isLoading: isReservationDetailsLoading } =
-    useReservationDetails(reservationId);
+    useReservationDetails(resolvedReservationId);
 
   const postReviewMutation = usePostReviewMutation();
+  const updateReviewMutation = useUpdateReviewMutation();
+
+  useEffect(() => {
+    if (mode === 'edit' && reviewDetail) {
+      dispatch({ type: 'SET_RATING', payload: reviewDetail.rating });
+      reviewDetail.quickReplyIds.forEach((id) => {
+        dispatch({ type: 'TOGGLE_QUICK_REPLY', payload: id });
+      });
+      dispatch({ type: 'SET_COMMENT', payload: reviewDetail.comment });
+      if (reviewDetail.reviewImageUrl) {
+        dispatch({ type: 'SET_IMAGE', payload: reviewDetail.reviewImageUrl });
+      }
+    }
+  }, [mode, reviewDetail]);
 
   const handleRatingChange = (rating: number) => {
     dispatch({ type: 'SET_RATING', payload: rating });
@@ -74,25 +102,43 @@ export default function ReviewRegisterForm({ reservationId }: ReviewRegisterForm
       rating: state.rating,
       quickReplyIds: state.selectedQuickReplies,
       comment: state.comment.trim(),
-      file: state.image,
+      file: typeof state.image === 'string' ? undefined : state.image,
     };
 
-    postReviewMutation.mutate(
-      { reservationId, reviewData },
-      {
-        onSuccess: () => {
-          makeToast('리뷰가 등록되었습니다!', 'success');
-          handleReset();
-          router.push(
-            PATH.RENTAL.STORE_DETAIL.replace(':storeId', String(reservationDetailsData?.storeId)),
-          );
+    if (mode === 'register') {
+      postReviewMutation.mutate(
+        { reservationId, reviewData: { ...reviewData, reservationId } },
+        {
+          onSuccess: () => {
+            makeToast('리뷰가 등록되었습니다!', 'success');
+            handleReset();
+            router.push(
+              PATH.RENTAL.STORE_DETAIL.replace(':storeId', String(reservationDetailsData?.storeId)),
+            );
+          },
+          onError: (error) => {
+            console.error('리뷰 등록 실패: ', error);
+            makeToast('리뷰 등록에 실패했습니다.', 'warning');
+          },
         },
-        onError: (error) => {
-          console.error('리뷰 등록 실패: ', error);
-          makeToast('리뷰 등록에 실패했습니다.', 'warning');
+      );
+    } else if (mode === 'edit' && reviewDetail) {
+      updateReviewMutation.mutate(
+        { reviewId: reviewDetail.reviewId, reviewData },
+        {
+          onSuccess: () => {
+            makeToast('리뷰가 수정되었습니다!', 'success');
+            router.push(
+              PATH.RENTAL.STORE_DETAIL.replace(':storeId', String(reservationDetailsData?.storeId)),
+            );
+          },
+          onError: (error) => {
+            console.error('리뷰 수정 실패: ', error);
+            makeToast('리뷰 수정에 실패했습니다.', 'warning');
+          },
         },
-      },
-    );
+      );
+    }
   };
 
   if (isQuickRepliesLoading || isReservationDetailsLoading) {
@@ -102,6 +148,7 @@ export default function ReviewRegisterForm({ reservationId }: ReviewRegisterForm
   if (!quickRepliesData || !reservationDetailsData) {
     return <div>데이터를 불러오는데 실패했습니다.</div>;
   }
+
   return (
     <>
       <ReservationDetailsSection reservationDetails={reservationDetailsData} />
@@ -120,7 +167,7 @@ export default function ReviewRegisterForm({ reservationId }: ReviewRegisterForm
         variant="primary"
         size="lg"
       >
-        등록하기
+        {mode === 'edit' ? '수정하기' : '등록하기'}
       </RegisterButton>
     </>
   );

--- a/src/features/rental/store/review/page/ReviewPage.tsx
+++ b/src/features/rental/store/review/page/ReviewPage.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 
 import { useParams } from 'next/navigation';
 
+import { useAuthStore } from '@/entities/auth/model/authStore';
 import {
   useInfiniteStoreReviews,
   useStoreReviewMeta,
@@ -17,6 +18,7 @@ import type { ReviewSortType } from '@/features/rental/store/review/lib/types';
 export default function ReviewPage() {
   const params = useParams();
   const storeId = Number(params?.storeId);
+  const { user } = useAuthStore();
   const [selectedSort, setSelectedSort] = useState<ReviewSortType>('latest');
 
   const { data: metaData, isLoading: metaLoading } = useStoreReviewMeta(storeId);
@@ -63,7 +65,11 @@ export default function ReviewPage() {
         {allReviews.length > 0 ? (
           <>
             {allReviews.map((review) => (
-              <ReviewItem key={review.reviewId} review={review} />
+              <ReviewItem
+                key={review.reviewId}
+                review={review}
+                isOwner={user?.userId === review.writerId}
+              />
             ))}
 
             {hasNextPage && (

--- a/src/features/rental/store/review/ui/ReviewItem.tsx
+++ b/src/features/rental/store/review/ui/ReviewItem.tsx
@@ -9,7 +9,6 @@ import { useDeleteReviewMutation } from '@/features/rental/store/register-review
 import { formatDateToDash } from '@/features/rental/store/review/lib/utils';
 import { ICONS } from '@/shared/config/iconPath';
 import { PATH } from '@/shared/config/path';
-import { makeToast } from '@/shared/lib/makeToast';
 import { Drawer, DrawerButton } from '@/shared/ui/Drawer';
 import { Profile } from '@/shared/ui/Profile';
 
@@ -41,14 +40,7 @@ export default function ReviewItem({ review, isOwner }: ReviewItemProps) {
 
   const handleDelete = () => {
     if (window.confirm('리뷰를 삭제하시겠습니까?')) {
-      deleteReviewMutation.mutate(review.reviewId, {
-        onSuccess: () => {
-          makeToast('리뷰가 삭제되었습니다.', 'success');
-        },
-        onError: () => {
-          makeToast('리뷰 삭제에 실패했습니다.', 'warning');
-        },
-      });
+      deleteReviewMutation.mutate(review.reviewId);
     }
   };
 

--- a/src/features/rental/store/review/ui/ReviewItem.tsx
+++ b/src/features/rental/store/review/ui/ReviewItem.tsx
@@ -5,14 +5,13 @@ import { useRouter } from 'next/navigation';
 
 import { MoreHorizontal } from 'lucide-react';
 
+import { useDeleteReviewMutation } from '@/features/rental/store/register-review/model/mutations';
+import { formatDateToDash } from '@/features/rental/store/review/lib/utils';
 import { ICONS } from '@/shared/config/iconPath';
 import { PATH } from '@/shared/config/path';
 import { makeToast } from '@/shared/lib/makeToast';
 import { Drawer, DrawerButton } from '@/shared/ui/Drawer';
 import { Profile } from '@/shared/ui/Profile';
-
-import { useDeleteReviewMutation } from '../../register-review/model/mutations';
-import { formatDateToDash } from '../lib/utils';
 
 import type { ReviewItem as ReviewItemType } from '@/features/rental/store/review/lib/types.ts';
 

--- a/src/features/rental/store/review/ui/ReviewItem.tsx
+++ b/src/features/rental/store/review/ui/ReviewItem.tsx
@@ -1,15 +1,24 @@
 import { useState } from 'react';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
-import { formatDateToDash } from '@/features/rental/store/review/lib/utils';
+import { MoreHorizontal } from 'lucide-react';
+
 import { ICONS } from '@/shared/config/iconPath';
+import { PATH } from '@/shared/config/path';
+import { makeToast } from '@/shared/lib/makeToast';
+import { Drawer, DrawerButton } from '@/shared/ui/Drawer';
 import { Profile } from '@/shared/ui/Profile';
+
+import { useDeleteReviewMutation } from '../../register-review/model/mutations';
+import { formatDateToDash } from '../lib/utils';
 
 import type { ReviewItem as ReviewItemType } from '@/features/rental/store/review/lib/types.ts';
 
 interface ReviewItemProps {
   review: ReviewItemType;
+  isOwner: boolean;
 }
 
 const QuickReplyTag = ({ text }: { text: string }) => {
@@ -20,82 +29,132 @@ const QuickReplyTag = ({ text }: { text: string }) => {
   );
 };
 
-export default function ReviewItem({ review }: ReviewItemProps) {
+export default function ReviewItem({ review, isOwner }: ReviewItemProps) {
+  const router = useRouter();
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const deleteReviewMutation = useDeleteReviewMutation();
+
+  const handleEdit = () => {
+    setIsDrawerOpen(false);
+    router.push(`${PATH.RENTAL.REGISTER_REVIEW}?mode=edit&reviewId=${review.reviewId}`);
+  };
+
+  const handleDelete = () => {
+    if (window.confirm('리뷰를 삭제하시겠습니까?')) {
+      deleteReviewMutation.mutate(review.reviewId, {
+        onSuccess: () => {
+          makeToast('리뷰가 삭제되었습니다.', 'success');
+        },
+        onError: () => {
+          makeToast('리뷰 삭제에 실패했습니다.', 'warning');
+        },
+      });
+    }
+  };
+
   const maxLength = 100;
   const shouldShowMore = review.comment.length > maxLength;
-
   const displayText =
     isExpanded || !shouldShowMore ? review.comment : review.comment.slice(0, maxLength) + '...';
 
   const formattedDate = formatDateToDash(review.rentalStartDate);
 
   return (
-    <div className="border-b border-[var(--gray-light)] pb-6 mb-6 last:border-b-0">
-      <Profile
-        avatar={review.userImageUrl}
-        name={review.name}
-        size="sm"
-        bottomContent={
-          <>
-            <div className="flex items-center gap-1">
-              <Image src={ICONS.ETC.LIKE_ACTIVE} width={18} height={18} alt="별점" />
-              <span className="font-label-medium text-[var(--main-5)]">
-                {review.rating.toFixed(1)}
+    <>
+      <div className="relative border-b border-[var(--gray-light)] pb-6 mb-6 last:border-b-0">
+        <Profile
+          avatar={review.userImageUrl}
+          name={review.name}
+          size="sm"
+          bottomContent={
+            <>
+              <div className="flex items-center gap-1">
+                <Image src={ICONS.ETC.LIKE_ACTIVE} width={18} height={18} alt="별점" />
+                <span className="font-label-medium text-[var(--main-5)]">
+                  {review.rating.toFixed(1)}
+                </span>
+              </div>
+              <span className="font-caption-regular text-[var(--gray-dark)]">
+                {formattedDate} · {review.countOfVisit}번째 방문
               </span>
-            </div>
-            <span className="font-caption-regular text-[var(--gray-dark)]">
-              {formattedDate} · {review.countOfVisit}번째 방문
-            </span>
-          </>
-        }
-      />
+            </>
+          }
+        />
 
-      {review.reviewImageUrl && (
-        <div className="mt-4 mb-2">
-          <Image
-            src={review.reviewImageUrl}
-            alt="리뷰 이미지"
-            width={200}
-            height={140}
-            className="w-full h-[140px] object-contain rounded-lg bg-[var(--gray-light)]"
-          />
-        </div>
-      )}
-      <div className="flex flex-row gap-4">
-        {review.reservedDeviceOnReviewResponses.map((device, index) => (
-          <span
-            key={index}
-            className="inline-block my-2 px-3 py-1 bg-[var(--gray-light)] text-[var(--black)] font-small-regular rounded-sm"
-          >
-            <span className="text-[var(--main-5)] font-small-semibold">
-              {device.dataCapacity}GB&nbsp;
-            </span>
-            {device.deviceName}
-          </span>
-        ))}
-      </div>
-      <div className="mb-4 space-y-2">
-        <p className="font-label-regular leading-relaxed whitespace-pre-wrap break-all">
-          {displayText}
-        </p>
-        {shouldShowMore && (
+        {isOwner && (
           <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="text-[var(--gray-mid)] font-small-regular hover:underline mt-1"
+            onClick={() => setIsDrawerOpen(true)}
+            className="absolute top-0 right-0 p-2 hover:bg-[var(--gray-light)] rounded-full"
           >
-            {isExpanded ? '접기' : '더보기'}
+            <MoreHorizontal width={20} height={20} />
           </button>
         )}
 
-        {review.quickReplyNames.length > 0 && (
-          <div className="flex flex-wrap gap-2 mb-2">
-            {review.quickReplyNames.map((tag, index) => (
-              <QuickReplyTag key={index} text={tag} />
-            ))}
+        {review.reviewImageUrl && (
+          <div className="mt-4 mb-2">
+            <Image
+              src={review.reviewImageUrl}
+              alt="리뷰 이미지"
+              width={200}
+              height={140}
+              className="w-full h-[140px] object-contain rounded-lg bg-[var(--gray-light)]"
+            />
           </div>
         )}
+
+        <div className="flex flex-row gap-4">
+          {review.reservedDeviceOnReviewResponses.map((device, index) => (
+            <span
+              key={index}
+              className="inline-block my-2 px-3 py-1 bg-[var(--gray-light)] text-[var(--black)] font-small-regular rounded-sm"
+            >
+              <span className="text-[var(--main-5)] font-small-semibold">
+                {device.dataCapacity}GB&nbsp;
+              </span>
+              {device.deviceName}
+            </span>
+          ))}
+        </div>
+        <div className="mb-4 space-y-2">
+          <p className="font-label-regular leading-relaxed whitespace-pre-wrap break-all">
+            {displayText}
+          </p>
+          {shouldShowMore && (
+            <button
+              onClick={() => setIsExpanded(!isExpanded)}
+              className="text-[var(--gray-mid)] font-small-regular hover:underline mt-1"
+            >
+              {isExpanded ? '접기' : '더보기'}
+            </button>
+          )}
+
+          {review.quickReplyNames.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-2">
+              {review.quickReplyNames.map((tag, index) => (
+                <QuickReplyTag key={index} text={tag} />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+
+      <Drawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)}>
+        <div className="space-y-2">
+          <div>
+            <DrawerButton onClick={handleEdit}>리뷰 수정</DrawerButton>
+            <DrawerButton onClick={handleDelete} variant="point">
+              리뷰 삭제
+            </DrawerButton>
+          </div>
+
+          <div>
+            <DrawerButton onClick={() => setIsDrawerOpen(false)} variant="close">
+              닫기
+            </DrawerButton>
+          </div>
+        </div>
+      </Drawer>
+    </>
   );
 }

--- a/src/shared/config/errorCodes.ts
+++ b/src/shared/config/errorCodes.ts
@@ -24,6 +24,9 @@ export enum ErrorCode {
   // 유저 팔로우
   FOLLOW_SELF_ERROR = 2014,
   FOLLOW_USER_NOT_FOUND = 2011,
+
+  // 리뷰
+  REVIEW_DELETE_NOT_ALLOWED = 4019,
 }
 
 export const ErrorMessageMap: Record<ErrorCode, string> = {
@@ -53,4 +56,7 @@ export const ErrorMessageMap: Record<ErrorCode, string> = {
   // 유저 팔로우
   [ErrorCode.FOLLOW_SELF_ERROR]: '자기 자신을 팔로우할 수 없습니다.',
   [ErrorCode.FOLLOW_USER_NOT_FOUND]: '유저 정보를 찾을 수 없습니다.',
+
+  // 리뷰
+  [ErrorCode.REVIEW_DELETE_NOT_ALLOWED]: '작성한 지 7일 이내의 리뷰는 삭제할 수 없습니다.',
 };

--- a/src/shared/lib/axios/errorHandler.ts
+++ b/src/shared/lib/axios/errorHandler.ts
@@ -1,5 +1,8 @@
+import { ErrorMessageMap } from '@/shared/config/errorCodes';
+
 import { HTTPError } from '../HTTPError';
 
+import type { ErrorCode } from '@/shared/config/errorCodes';
 import type { ErrorResponse } from '@/shared/lib/axios/responseTypes';
 import type { AxiosError } from 'axios';
 
@@ -9,5 +12,9 @@ export const handleAPIError = (error: AxiosError<ErrorResponse>) => {
   }
 
   const { data, status } = error.response;
-  throw new HTTPError(status, data.code, data.content, data.message);
+
+  const fallbackMessage =
+    ErrorMessageMap[data.code as ErrorCode] ?? data.message ?? '알 수 없는 오류가 발생했습니다.';
+
+  throw new HTTPError(status, data.code, data.content, fallbackMessage);
 };


### PR DESCRIPTION
### #️⃣연관된 이슈

> close: #193 

### 🔎 작업 내용

- [x] 리뷰 수정 모드 추가 (`mode: 'register' | 'edit'`)
- [x] `useReviewDetailQuery` 추가하여 수정할 리뷰 데이터 조회
- [x] `ReviewRegisterPageContent`에서 URL 파라미터 기반 mode/reviewId 처리
- [x] updateReview API 및 useUpdateReviewMutation 구현
- [x] 수정 모드일 때 기존 리뷰 데이터로 폼 초기화
- [x] 리뷰 삭제 기능 및 에러 처리 추가
- [x] ReviewItem에서 수정/삭제 Drawer UI 구현

### 📸 스크린샷
![화면 기록 2025-07-30 오후 10 14 09](https://github.com/user-attachments/assets/f63c5cfa-4c88-477c-9d94-d4a262265fe5)

- 리뷰 등록 후 7일이 지난 리뷰는 삭제하지 못한다는 커스텀 에러 코드 메시지 토스트 알림 추가
<img width="602" height="408" alt="스크린샷 2025-07-30 오후 10 57 55" src="https://github.com/user-attachments/assets/ee5af61d-cb37-4e26-81fb-d6a43c3da17a" />

### :loudspeaker: 전달사항
- 리뷰 삭제 성공 시 토스트 알림이 중복되어 뜰 수도 있습니다...!! 추후에 확인 후 문제 있으면 수정하겠습니다!
- 거래 리뷰 UI 관련해서 전체적으로 하단 마진이 필요할 거 같습니다. 추후 수정하겠습니다!

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
