### PR TITLE
Feature/bada 398 rental apis

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,7 @@
 @import 'tailwindcss';
 @import '../shared/styles/radius.css';
 @import '../shared/styles/custom-scrollbar.css';
+@import '../shared/styles/list-animations.css';
 @import 'swiper/css';
 @import 'swiper/css/pagination';
 @import 'swiper/css/navigation';

--- a/src/features/mypage/like-store/page/LikeStorePage.tsx
+++ b/src/features/mypage/like-store/page/LikeStorePage.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import { useRouter } from 'next/navigation';
 
 import { useLikedStores } from '@/features/mypage/like-store/model/queries';
@@ -10,10 +12,22 @@ import { PageHeader } from '@/shared/ui/Header';
 export default function LikeStorePage() {
   const router = useRouter();
   const { likeStoreItems, isLoading, isError } = useLikedStores();
+  const [removedStoreIds, setRemovedStoreIds] = useState<Set<number>>(new Set());
+
+  // 좋아요 취소 시 리스트에서 제거
+  const handleLikeToggle = (storeId: number, isLiked: boolean) => {
+    if (!isLiked) {
+      // 좋아요가 취소되면 리스트에서 제거
+      setRemovedStoreIds((prev) => new Set([...prev, storeId]));
+    }
+  };
+
+  // 제거된 스토어를 필터링
+  const filteredItems = likeStoreItems?.filter((item) => !removedStoreIds.has(item.storeId)) || [];
 
   if (isLoading) return <div>로딩중...</div>;
   if (isError) return <div>에러가 발생했습니다.</div>;
-  if (!likeStoreItems || likeStoreItems.length === 0) {
+  if (!filteredItems || filteredItems.length === 0) {
     return <div className="py-4 text-center text-[var(--gray)]">게시물이 없습니다.</div>;
   }
 
@@ -23,7 +37,7 @@ export default function LikeStorePage() {
       showBottomNav
     >
       <div className="flex flex-col items-center gap-4 px-4 pt-6 pb-[96px]">
-        {likeStoreItems.map((item) => (
+        {filteredItems.map((item) => (
           <StoreCard
             key={item.storeId}
             id={item.storeId}
@@ -45,6 +59,8 @@ export default function LikeStorePage() {
             deviceCount={item.availableDevice}
             isLiked={true}
             showDistance={false}
+            onLikeToggle={handleLikeToggle}
+            disableToast={true}
             className="font-title-regular w-[95%] max-w-[400px]"
           />
         ))}

--- a/src/features/mypage/like-store/page/LikeStorePage.tsx
+++ b/src/features/mypage/like-store/page/LikeStorePage.tsx
@@ -13,12 +13,23 @@ export default function LikeStorePage() {
   const router = useRouter();
   const { likeStoreItems, isLoading, isError } = useLikedStores();
   const [removedStoreIds, setRemovedStoreIds] = useState<Set<number>>(new Set());
+  const [removingStoreIds, setRemovingStoreIds] = useState<Set<number>>(new Set());
 
   // 좋아요 취소 시 리스트에서 제거
   const handleLikeToggle = (storeId: number, isLiked: boolean) => {
     if (!isLiked) {
-      // 좋아요가 취소되면 리스트에서 제거
-      setRemovedStoreIds((prev) => new Set([...prev, storeId]));
+      // 애니메이션을 위한 제거 중 상태 설정
+      setRemovingStoreIds((prev) => new Set([...prev, storeId]));
+
+      // 애니메이션 완료 후 실제 제거
+      setTimeout(() => {
+        setRemovedStoreIds((prev) => new Set([...prev, storeId]));
+        setRemovingStoreIds((prev) => {
+          const newSet = new Set(prev);
+          newSet.delete(storeId);
+          return newSet;
+        });
+      }, 500); // 애니메이션 지속 시간
     }
   };
 
@@ -37,33 +48,52 @@ export default function LikeStorePage() {
       showBottomNav
     >
       <div className="flex flex-col items-center gap-4 px-4 pt-6 pb-[96px]">
-        {filteredItems.map((item) => (
-          <StoreCard
-            key={item.storeId}
-            id={item.storeId}
-            store={{
-              id: item.storeId,
-              name: item.name,
-              latitude: 0,
-              longititude: 0,
-            }}
-            storeDetail={{
-              name: item.name,
-              storeId: item.storeId,
-              startTime: item.startTime,
-              endTime: item.endTime,
-              imageUrl: item.storeImage,
-              detailAddress: item.detailAddress,
-              isOpening: true, // 실제 오픈 여부는 별도 로직 필요
-            }}
-            deviceCount={item.availableDevice}
-            isLiked={true}
-            showDistance={false}
-            onLikeToggle={handleLikeToggle}
-            disableToast={true}
-            className="font-title-regular w-[95%] max-w-[400px]"
-          />
-        ))}
+        {filteredItems.map((item, index) => {
+          const isRemoving = removingStoreIds.has(item.storeId);
+
+          return (
+            <div
+              key={item.storeId}
+              className={`transition-all duration-500 ease-in-out ${
+                isRemoving
+                  ? 'animate-slide-out-down'
+                  : `animate-slide-in-up animate-stagger-${Math.min(index + 1, 5)}`
+              }`}
+              style={{
+                transform: isRemoving ? 'translateY(100%) scale(0.8)' : 'translateY(0) scale(1)',
+                opacity: isRemoving ? 0 : 1,
+                height: isRemoving ? '0' : 'auto',
+                marginBottom: isRemoving ? '0' : '16px',
+                overflow: 'hidden',
+              }}
+            >
+              <StoreCard
+                id={item.storeId}
+                store={{
+                  id: item.storeId,
+                  name: item.name,
+                  latitude: 0,
+                  longititude: 0,
+                }}
+                storeDetail={{
+                  name: item.name,
+                  storeId: item.storeId,
+                  startTime: item.startTime,
+                  endTime: item.endTime,
+                  imageUrl: item.storeImage,
+                  detailAddress: item.detailAddress,
+                  isOpening: true, // 실제 오픈 여부는 별도 로직 필요
+                }}
+                deviceCount={item.availableDevice}
+                isLiked={true}
+                showDistance={false}
+                onLikeToggle={handleLikeToggle}
+                disableToast={true}
+                className="font-title-regular w-[95%] max-w-[400px]"
+              />
+            </div>
+          );
+        })}
       </div>
     </BaseLayout>
   );

--- a/src/features/mypage/like-store/page/LikeStorePage.tsx
+++ b/src/features/mypage/like-store/page/LikeStorePage.tsx
@@ -36,6 +36,11 @@ export default function LikeStorePage() {
   // 제거된 스토어를 필터링
   const filteredItems = likeStoreItems?.filter((item) => !removedStoreIds.has(item.storeId)) || [];
 
+  console.log('🔗 LikeStorePage - likeStoreItems:', likeStoreItems);
+  console.log('🔗 LikeStorePage - isLoading:', isLoading);
+  console.log('🔗 LikeStorePage - isError:', isError);
+  console.log('🔗 LikeStorePage - filteredItems:', filteredItems);
+
   if (isLoading) return <div>로딩중...</div>;
   if (isError) return <div>에러가 발생했습니다.</div>;
   if (!filteredItems || filteredItems.length === 0) {
@@ -74,6 +79,8 @@ export default function LikeStorePage() {
                   name: item.name,
                   latitude: 0,
                   longititude: 0,
+                  leftDeviceCount: item.availableDevice,
+                  liked: true,
                 }}
                 storeDetail={{
                   name: item.name,

--- a/src/features/mypage/restock-alarm/api/apis.ts
+++ b/src/features/mypage/restock-alarm/api/apis.ts
@@ -15,3 +15,11 @@ export const getRestockAlarmList = async (
     throw error;
   }
 };
+
+export const deleteRestockAlarm = async (restockId: number): Promise<void> => {
+  try {
+    await axiosInstance.delete(END_POINTS.RENTAL.RENTAL_CANCEL(restockId));
+  } catch (error: unknown) {
+    throw error;
+  }
+};

--- a/src/features/mypage/restock-alarm/model/queries.ts
+++ b/src/features/mypage/restock-alarm/model/queries.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getRestockAlarmList } from '@/features/mypage/restock-alarm/api/apis';
+import { deleteRestockAlarm, getRestockAlarmList } from '@/features/mypage/restock-alarm/api/apis';
 
 import type { RestockAlarmItem } from '@/features/mypage/restock-alarm/lib/types';
 
@@ -9,3 +9,17 @@ export const useRestockAlarmListQuery = () =>
     queryKey: ['restockAlarmList'],
     queryFn: () => getRestockAlarmList(),
   });
+
+export const useDeleteRestockAlarmMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteRestockAlarm,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['restockAlarmList'] });
+    },
+    onError: (error, restockId) => {
+      console.error('삭제 mutation 실패:', restockId, error);
+    },
+  });
+};

--- a/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
+++ b/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
@@ -1,18 +1,66 @@
 'use client';
 
+import { useState } from 'react';
+
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-import { useRestockAlarmListQuery } from '@/features/mypage/restock-alarm/model/queries';
+import {
+  useDeleteRestockAlarmMutation,
+  useRestockAlarmListQuery,
+} from '@/features/mypage/restock-alarm/model/queries';
+import { makeToast } from '@/shared/lib/makeToast';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { PageHeader } from '@/shared/ui/Header';
+import { Modal } from '@/shared/ui/Modal';
 
 import type { RestockAlarmItem } from '@/features/mypage/restock-alarm/lib/types';
 
 export default function RestockAlarmPage() {
   const router = useRouter();
   const { data, isLoading, isError } = useRestockAlarmListQuery();
+  const deleteMutation = useDeleteRestockAlarmMutation();
   const alarms: RestockAlarmItem[] = data?.item || [];
+  const [deletingIds, setDeletingIds] = useState<Set<number>>(new Set());
+
+  // 확인 모달 상태
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [itemToDelete, setItemToDelete] = useState<RestockAlarmItem | null>(null);
+
+  const handleDeleteClick = (item: RestockAlarmItem) => {
+    setItemToDelete(item);
+    setShowConfirmModal(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!itemToDelete) return;
+
+    try {
+      setDeletingIds((prev) => new Set(prev).add(itemToDelete.id));
+
+      await deleteMutation.mutateAsync(itemToDelete.id);
+
+      makeToast('재입고 알림을 해제하였습니다.', 'success');
+    } catch (error) {
+      console.error('재입고 알림 삭제 실패:', error);
+      makeToast('재입고 알림 삭제에 실패했습니다.', 'warning');
+    } finally {
+      setDeletingIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(itemToDelete.id);
+        return newSet;
+      });
+    }
+
+    // 모달 닫기
+    setShowConfirmModal(false);
+    setItemToDelete(null);
+  };
+
+  const handleCancelDelete = () => {
+    setShowConfirmModal(false);
+    setItemToDelete(null);
+  };
 
   return (
     <BaseLayout
@@ -39,38 +87,51 @@ export default function RestockAlarmPage() {
           <div className="text-center py-8 text-[var(--gray-mid)]">알림 내역이 없습니다.</div>
         ) : (
           <ul className="flex flex-col gap-4">
-            {alarms.map((item) => (
-              <li key={item.id} className="flex gap-3 p-0 min-h-[72px]">
-                <div className="w-[72px] h-[72px] bg-[var(--gray-light)] rounded-md overflow-hidden flex-shrink-0">
-                  <Image
-                    src={item.deviceImage}
-                    alt="상품 이미지"
-                    width={72}
-                    height={72}
-                    className="object-cover w-full h-full"
-                  />
-                </div>
-                <div className="flex-1 min-w-0 flex flex-col justify-between h-[72px]">
-                  <div className="flex items-start w-full">
-                    <div className="font-body-xs-semibold text-[var(--black)] leading-tight break-words whitespace-pre-line overflow-hidden max-h-[52px] flex-1 line-clamp-2">
-                      {item.deviceName} {item.is5G ? '(5G)' : ''}
+            {alarms.map((item) => {
+              const isDeleting = deletingIds.has(item.id);
+
+              return (
+                <li key={item.id} className="flex gap-3 p-0 min-h-[72px]">
+                  <div className="w-[72px] h-[72px] bg-[var(--gray-light)] rounded-md overflow-hidden flex-shrink-0">
+                    <Image
+                      src={item.deviceImage}
+                      alt="상품 이미지"
+                      width={72}
+                      height={72}
+                      className="object-cover w-full h-full"
+                    />
+                  </div>
+                  <div className="flex-1 min-w-0 flex flex-col justify-between h-[72px]">
+                    <div className="flex items-start w-full">
+                      <div className="font-body-xs-semibold text-[var(--black)] leading-tight break-words whitespace-pre-line overflow-hidden max-h-[52px] flex-1 line-clamp-2">
+                        {item.deviceName} {item.is5G ? '(5G)' : ''}
+                      </div>
+                      <button
+                        className={`cursor-pointer text-[20px] px-2 py-0 ml-2 flex-shrink-0 relative -top-2 ${
+                          isDeleting
+                            ? 'text-[var(--gray-light)] cursor-not-allowed'
+                            : 'text-[var(--gray-mid)] hover:text-[var(--red-main)]'
+                        }`}
+                        aria-label="삭제"
+                        onClick={() => {
+                          if (!isDeleting) {
+                            handleDeleteClick(item);
+                          }
+                        }}
+                        disabled={isDeleting}
+                      >
+                        {isDeleting ? '⋯' : '×'}
+                      </button>
                     </div>
-                    <button
-                      className="text-[20px] text-[var(--gray-mid)] px-2 py-0 ml-2 flex-shrink-0 relative -top-2"
-                      aria-label="삭제"
-                      disabled
-                    >
-                      ×
-                    </button>
+                    <div className="flex items-end justify-start w-full mt-1">
+                      <span className="font-body-xs-semibold text-[var(--main-5)]">
+                        {item.price.toLocaleString()}원
+                      </span>
+                    </div>
                   </div>
-                  <div className="flex items-end justify-start w-full mt-1">
-                    <span className="font-body-xs-semibold text-[var(--main-5)]">
-                      {item.price.toLocaleString()}원
-                    </span>
-                  </div>
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
 
@@ -94,6 +155,34 @@ export default function RestockAlarmPage() {
           </div>
         </div>
       </div>
+
+      {/* 확인 모달 */}
+      <Modal isOpen={showConfirmModal} onClose={handleCancelDelete}>
+        <div className="p-6 w-[280px] mx-auto">
+          <div className="text-center mb-6">
+            <h3 className="font-title-semibold text-[var(--black)] text-lg mb-2">
+              재입고 알림 취소
+            </h3>
+            <p className="font-body-light-lh text-[var(--gray-mid)]">
+              재입고 알림을 취소하시겠습니까?
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={handleCancelDelete}
+              className="flex-1 py-3 px-4 font-body-semibold bg-[var(--gray-light)] border border-[var(--gray-light)] rounded-lg hover:bg-[var(--gray-light)]"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleConfirmDelete}
+              className="flex-1 py-3 text-[var(--white)] px-4 font-body-semibold bg-[var(--main-5)] rounded-lg hover:bg-[var(--main-4)]"
+            >
+              확인
+            </button>
+          </div>
+        </div>
+      </Modal>
     </BaseLayout>
   );
 }

--- a/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
+++ b/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
@@ -9,10 +9,11 @@ import {
   useDeleteRestockAlarmMutation,
   useRestockAlarmListQuery,
 } from '@/features/mypage/restock-alarm/model/queries';
+import { AlarmNoticeSection } from '@/features/mypage/ui/AlarmNoticeSection';
+import { DeleteConfirmModal } from '@/features/mypage/ui/DeleteConfirmModal';
 import { makeToast } from '@/shared/lib/makeToast';
 import { BaseLayout } from '@/shared/ui/BaseLayout';
 import { PageHeader } from '@/shared/ui/Header';
-import { Modal } from '@/shared/ui/Modal';
 
 import type { RestockAlarmItem } from '@/features/mypage/restock-alarm/lib/types';
 
@@ -21,6 +22,7 @@ export default function RestockAlarmPage() {
   const { data, isLoading, isError } = useRestockAlarmListQuery();
   const deleteMutation = useDeleteRestockAlarmMutation();
   const alarms: RestockAlarmItem[] = data?.item || [];
+
   const [deletingIds, setDeletingIds] = useState<Set<number>>(new Set());
 
   // 확인 모달 상태
@@ -68,6 +70,7 @@ export default function RestockAlarmPage() {
       showBottomNav
     >
       <div className="w-full max-w-[428px] flex-1 overflow-y-auto pt-0 pb-[84px] px-4">
+        <AlarmNoticeSection />
         <div className="flex items-center justify-between mt-6 mb-4">
           <span className="font-body-semibold text-[var(--black)]">
             전체 <span className="text-[var(--main-5)]">{alarms.length}</span>개
@@ -135,54 +138,13 @@ export default function RestockAlarmPage() {
           </ul>
         )}
 
-        <div className="mt-6 rounded-xl border-2 border-[var(--gray-light)] bg-[var(--white)] overflow-hidden">
-          <div className="flex items-center gap-2 px-3 py-2 bg-[var(--main-1)]">
-            <span className="font-body-xs-semibold text-[var(--main-5)]">ⓘ</span>
-            <span className="font-body-xs-semibold text-[var(--black)]">이용안내</span>
-          </div>
-          <div className="px-3 pb-3 pt-0 bg-[var(--white)]">
-            <ul className="list-disc pl-4">
-              <li className="font-body-light-lh text-[var(--gray-mid)] mb-1">
-                기기의 입고 시점에 따라 1회 발송되고, 이미 발송된 재입고 알림은 다시 발송되지
-                않으므로 고객님께서 확인 후 원하실 때만 알림을 다시 받고 싶으실 경우 해당 상품
-                페이지에서 재신청해주시기 바랍니다.
-              </li>
-              <li className="font-body-light-lh text-[var(--gray-mid)]">
-                대여 기간 내에 기기가 재고로 되지 않게 되면 재입고 알림 신청 내역에서 자동으로
-                삭제됩니다.
-              </li>
-            </ul>
-          </div>
-        </div>
+        <DeleteConfirmModal
+          isOpen={showConfirmModal}
+          onClose={handleCancelDelete}
+          onConfirm={handleConfirmDelete}
+          item={itemToDelete}
+        />
       </div>
-
-      {/* 확인 모달 */}
-      <Modal isOpen={showConfirmModal} onClose={handleCancelDelete}>
-        <div className="p-6 w-[280px] mx-auto">
-          <div className="text-center mb-6">
-            <h3 className="font-title-semibold text-[var(--black)] text-lg mb-2">
-              재입고 알림 취소
-            </h3>
-            <p className="font-body-light-lh text-[var(--gray-mid)]">
-              재입고 알림을 취소하시겠습니까?
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <button
-              onClick={handleCancelDelete}
-              className="flex-1 py-3 px-4 font-body-semibold bg-[var(--gray-light)] border border-[var(--gray-light)] rounded-lg hover:bg-[var(--gray-light)]"
-            >
-              취소
-            </button>
-            <button
-              onClick={handleConfirmDelete}
-              className="flex-1 py-3 text-[var(--white)] px-4 font-body-semibold bg-[var(--main-5)] rounded-lg hover:bg-[var(--main-4)]"
-            >
-              확인
-            </button>
-          </div>
-        </div>
-      </Modal>
     </BaseLayout>
   );
 }

--- a/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
+++ b/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
@@ -81,20 +81,29 @@ export default function RestockAlarmPage() {
         </div>
 
         {isLoading ? (
-          <div className="text-center py-8 text-[var(--gray-mid)]">불러오는 중...</div>
+          <div className="text-center py-8 text-[var(--gray-mid)] animate-pulse">
+            <div className="loading-spinner mr-2"></div>
+            불러오는 중...
+          </div>
         ) : isError ? (
-          <div className="text-center py-8 text-[var(--red-main)]">
+          <div className="text-center py-8 text-[var(--red-main)] animate-fade-in">
             데이터를 불러오지 못했습니다.
           </div>
         ) : alarms.length === 0 ? (
-          <div className="text-center py-8 text-[var(--gray-mid)]">알림 내역이 없습니다.</div>
+          <div className="text-center py-8 text-[var(--gray-mid)] animate-fade-in">
+            알림 내역이 없습니다.
+          </div>
         ) : (
           <ul className="flex flex-col gap-4">
-            {alarms.map((item) => {
+            {alarms.map((item, index) => {
               const isDeleting = deletingIds.has(item.id);
+              const staggerClass = `animate-stagger-${Math.min(index + 1, 5)}`;
 
               return (
-                <li key={item.id} className="flex gap-3 p-0 min-h-[72px]">
+                <li
+                  key={item.id}
+                  className={`flex gap-3 p-0 min-h-[72px] animate-slide-in-up ${staggerClass}`}
+                >
                   <div className="w-[72px] h-[72px] bg-[var(--gray-light)] rounded-md overflow-hidden flex-shrink-0">
                     <Image
                       src={item.deviceImage}
@@ -110,10 +119,10 @@ export default function RestockAlarmPage() {
                         {item.deviceName} {item.is5G ? '(5G)' : ''}
                       </div>
                       <button
-                        className={`cursor-pointer text-[20px] px-2 py-0 ml-2 flex-shrink-0 relative -top-2 ${
+                        className={`cursor-pointer text-[20px] px-2 py-0 ml-2 flex-shrink-0 relative -top-2 transition-all duration-200 ${
                           isDeleting
                             ? 'text-[var(--gray-light)] cursor-not-allowed'
-                            : 'text-[var(--gray-mid)] hover:text-[var(--red-main)]'
+                            : 'text-[var(--gray-mid)] hover:text-[var(--red-main)] hover:scale-110'
                         }`}
                         aria-label="삭제"
                         onClick={() => {

--- a/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
+++ b/src/features/mypage/restock-alarm/page/RestockAlarmPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -36,6 +36,16 @@ export default function RestockAlarmPage() {
     setShowConfirmModal(true);
   };
 
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
   const handleConfirmDelete = async () => {
     if (!itemToDelete) return;
 
@@ -50,7 +60,7 @@ export default function RestockAlarmPage() {
       makeToast('재입고 알림을 해제하였습니다.', 'success');
 
       // 애니메이션 완료 후 실제 제거
-      setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         setRemovedAlarmIds((prev) => new Set([...prev, itemToDelete.id]));
         setRemovingAlarmIds((prev) => {
           const newSet = new Set(prev);

--- a/src/features/mypage/ui/AlarmNoticeSection.tsx
+++ b/src/features/mypage/ui/AlarmNoticeSection.tsx
@@ -1,0 +1,23 @@
+export function AlarmNoticeSection() {
+  return (
+    <div className="mt-6 rounded-xl border-2 border-[var(--gray-light)] bg-[var(--white)] overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2 bg-[var(--main-1)]">
+        <span className="font-body-xs-semibold text-[var(--main-5)]">ⓘ</span>
+        <span className="font-body-xs-semibold text-[var(--black)]">이용안내</span>
+      </div>
+      <div className="px-3 pb-3 pt-0 bg-[var(--white)]">
+        <ul className="list-disc pl-4">
+          <li className="font-body-light-lh text-[var(--gray-mid)] mb-1">
+            기기의 입고 시점에 따라 1회 발송되고, 이미 발송된 재입고 알림은 다시 발송되지 않으므로
+            고객님께서 확인 후 원하실 때만 알림을 다시 받고 싶으실 경우 해당 상품 페이지에서
+            재신청해주시기 바랍니다.
+          </li>
+          <li className="font-body-light-lh text-[var(--gray-mid)]">
+            대여 기간 내에 기기가 재고로 되지 않게 되면 재입고 알림 신청 내역에서 자동으로
+            삭제됩니다.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/features/mypage/ui/DeleteConfirmModal.tsx
+++ b/src/features/mypage/ui/DeleteConfirmModal.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Modal } from '@/shared/ui/Modal';
+
+import type { RestockAlarmItem } from '@/features/mypage/restock-alarm/lib/types';
+
+interface DeleteConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  item: RestockAlarmItem | null;
+}
+
+export function DeleteConfirmModal({ isOpen, onClose, onConfirm }: DeleteConfirmModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="p-6 w-[280px] mx-auto">
+        <div className="text-center mb-6">
+          <h3 className="font-title-semibold text-[var(--black)] mb-2">재입고 알림 취소</h3>
+          <p className="font-body-light-lh text-[var(--gray-mid)]">
+            재입고 알림을 취소하시겠습니까?
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="cursor-pointer flex-1 py-3 px-4 font-body-semibold bg-[var(--gray-light)] border border-[var(--gray-light)] rounded-lg hover:bg-[var(--gray-light)]"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            className="cursor-pointer flex-1 py-3 text-[var(--white)] px-4 font-body-semibold bg-[var(--main-5)] rounded-lg hover:bg-[var(--main-4)]"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/rental/map/api/apis.ts
+++ b/src/features/rental/map/api/apis.ts
@@ -124,9 +124,19 @@ export const fetchStoreList = async (params: StoreListParams): Promise<StoreList
 /**
  * 가맹점 좋아요/좋아요 취소 토글
  */
-export const toggleStoreLike = async (storeId: number, isLiked: boolean): Promise<boolean> => {
+export const toggleStoreLike = async (
+  storeId: number,
+  isLiked: boolean,
+  signal?: AbortSignal,
+): Promise<boolean> => {
   try {
-    await axiosInstance.post(END_POINTS.STORES.LIKESTORE(storeId));
+    await axiosInstance.post(
+      END_POINTS.STORES.LIKESTORE(storeId),
+      {},
+      {
+        signal,
+      },
+    );
     return !isLiked; // 토글된 상태 반환
   } catch (error) {
     throw error;

--- a/src/features/rental/map/api/apis.ts
+++ b/src/features/rental/map/api/apis.ts
@@ -31,13 +31,9 @@ export const fetchStores = async (params: FetchStoresParams): Promise<Store[]> =
       }
     });
 
-    const fullUrl = `${endpoint}?${queryParams.toString()}`;
-    console.log('🔗 API URL:', fullUrl);
-
     const response = await axiosInstance.get(endpoint, {
       params,
     });
-    console.log('🔗 resposne 확인:', response);
     // API 응답 구조 확인 및 처리
     let stores: Record<string, unknown>[] = [];
 
@@ -69,7 +65,7 @@ export const fetchStores = async (params: FetchStoresParams): Promise<Store[]> =
 
     return mappedStores;
   } catch (error) {
-    console.error('❌ fetchStores API 호출 실패:', error);
+    console.error(' fetchStores API 호출 실패:', error);
     return [];
   }
 };

--- a/src/features/rental/map/api/apis.ts
+++ b/src/features/rental/map/api/apis.ts
@@ -78,3 +78,15 @@ export const fetchStoreList = async (params: StoreListParams): Promise<StoreList
   });
   return response;
 };
+
+/**
+ * 가맹점 좋아요/좋아요 취소 토글
+ */
+export const toggleStoreLike = async (storeId: number, isLiked: boolean): Promise<boolean> => {
+  try {
+    await axiosInstance.post(END_POINTS.STORES.LIKESTORE(storeId));
+    return !isLiked; // 토글된 상태 반환
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/features/rental/map/hooks/useFetchStoresHooks.ts
+++ b/src/features/rental/map/hooks/useFetchStoresHooks.ts
@@ -61,7 +61,7 @@ export const useFetchStoresHooks = (
       // 500ms 디바운싱
       debounceRef.current = setTimeout(async () => {
         try {
-          console.log('🚀 API 호출 시작');
+          if (!map) return;
           setIsLoading(true);
 
           setCurrentBounds(newBounds);
@@ -69,10 +69,7 @@ export const useFetchStoresHooks = (
           lastFilterStateRef.current = filterState;
 
           const mergedParams = mapFilterStateToApiParams(newBounds, filterState, zoomLevel);
-          console.log('🔧 API 파라미터:', mergedParams);
-
           const stores = await fetchStores(mergedParams);
-          console.log('📦 받아온 stores 개수:', stores.length);
 
           // stores가 실제로 변경되었는지 확인
           const storesChanged = JSON.stringify(stores) !== JSON.stringify(lastStoresRef.current);
@@ -81,13 +78,15 @@ export const useFetchStoresHooks = (
             lastStoresRef.current = stores;
           }
         } catch (e) {
-          console.error('❌ 가맹점 불러오기 실패:', e);
+          console.error('가맹점 불러오기 실패:', e);
         } finally {
-          setIsLoading(false);
+          if (map) {
+            setIsLoading(false);
+          }
         }
       }, 500);
     } catch (error) {
-      console.error('❌ 맵 bounds 가져오기 실패:', error);
+      console.error('맵 bounds 가져오기 실패:', error);
     }
   }, [map, filterState]);
 
@@ -99,7 +98,6 @@ export const useFetchStoresHooks = (
 
     // 초기화 플래그 확인
     if (!isInitializedRef.current) {
-      console.log('🎯 맵 초기화 및 이벤트 리스너 등록');
       isInitializedRef.current = true;
 
       // 초기 로드
@@ -127,7 +125,6 @@ export const useFetchStoresHooks = (
   // filterState 변경 시 즉시 업데이트 (초기화 후에만)
   useEffect(() => {
     if (map && filterState && isInitializedRef.current) {
-      console.log('🔍 filterState 변경 감지');
       updateStoresByBounds();
     }
   }, [filterState, map, updateStoresByBounds]);

--- a/src/features/rental/map/hooks/useKakaoMapHooks.ts
+++ b/src/features/rental/map/hooks/useKakaoMapHooks.ts
@@ -8,20 +8,27 @@ declare global {
 
 // 현재 위치 마커를 한 번만 생성하는 함수
 const createCurrentLocationMarker = (map: kakao.maps.Map): kakao.maps.Marker => {
+  console.log('📍 현재 위치 마커 생성 시작');
+
   // 현재 위치 마커 생성
   const currentLocationMarker = new window.kakao.maps.Marker({
     map: map,
     position: map.getCenter(), // 초기 위치는 지도 중심
   });
 
+  console.log('📍 현재 위치 마커 생성 완료');
+
   // 현재 위치로 이동하는 함수
   const moveToCurrentLocation = () => {
+    console.log('📍 현재 위치로 이동 시도');
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
           const lat = position.coords.latitude;
           const lng = position.coords.longitude;
           const currentPosition = new window.kakao.maps.LatLng(lat, lng);
+
+          console.log('📍 현재 위치 획득:', { lat, lng });
 
           // 마커 위치 업데이트
           currentLocationMarker.setPosition(currentPosition);
@@ -30,7 +37,7 @@ const createCurrentLocationMarker = (map: kakao.maps.Map): kakao.maps.Marker => 
           map.setCenter(currentPosition);
         },
         (error) => {
-          console.error('현재 위치를 가져올 수 없습니다:', error);
+          console.error('❌ 현재 위치를 가져올 수 없습니다:', error);
         },
         {
           enableHighAccuracy: true,
@@ -39,7 +46,7 @@ const createCurrentLocationMarker = (map: kakao.maps.Map): kakao.maps.Marker => 
         },
       );
     } else {
-      console.error('이 브라우저에서는 위치 정보를 지원하지 않습니다.');
+      console.error('❌ 이 브라우저에서는 위치 정보를 지원하지 않습니다.');
     }
   };
 
@@ -60,16 +67,20 @@ export const useKakaoMapHooks = () => {
   const currentLocationMarkerRef = useRef<kakao.maps.Marker | null>(null);
 
   useEffect(() => {
+    console.log('🗺️ 카카오맵 초기화 시작');
+
     const script = document.createElement('script');
     script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&autoload=false`;
     script.async = true;
 
     script.onload = () => {
       window.kakao.maps.load(() => {
-        if (!mapRef.current) return;
+        if (!mapRef.current) {
+          return;
+        }
 
         const map = new window.kakao.maps.Map(mapRef.current, {
-          center: new window.kakao.maps.LatLng(37.5665, 126.978),
+          center: new window.kakao.maps.LatLng(35.1796, 129.0756), // 부산 좌표로 변경
           level: 4,
         });
 
@@ -77,7 +88,13 @@ export const useKakaoMapHooks = () => {
 
         // 현재 위치 마커를 맵 생성 시 한 번만 생성
         currentLocationMarkerRef.current = createCurrentLocationMarker(map);
+
+        console.log('✅ 맵 초기화 완료');
       });
+    };
+
+    script.onerror = () => {
+      console.error('❌ 카카오맵 스크립트 로드 실패');
     };
 
     document.head.appendChild(script);

--- a/src/features/rental/map/hooks/useLocationHooks.ts
+++ b/src/features/rental/map/hooks/useLocationHooks.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface Location {
   lat: number;
@@ -21,49 +21,83 @@ export function useLocation(): UseLocationReturn {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 디바운싱과 쓰로틀링을 위한 ref들
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const lastCallTimeRef = useRef<number>(0);
+  const lastCoordsRef = useRef<{ lat: number; lng: number } | null>(null);
+  const isInitializedRef = useRef(false);
+
   const isDev = process.env.NODE_ENV === 'development';
-  // 좌표를 주소로 변환하는 함수 (Kakao REST API 사용)
+
+  // 좌표를 주소로 변환하는 함수 (Kakao REST API 사용) - 강화된 디바운싱 적용
   const getAddressFromCoords = useCallback(async (lat: number, lng: number) => {
-    try {
-      const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_MAP_REST_API_KEY;
-      if (!KAKAO_REST_API_KEY) {
-        if (isDev) console.warn('Kakao REST API 키가 설정되지 않았습니다.');
-        setUserAddress('현재위치');
-        return;
-      }
+    // 이전 디바운스 타이머가 있다면 취소
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
 
-      const x = lng.toString();
-      const y = lat.toString();
-      const url = `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${x}&y=${y}`;
+    // 강화된 쓰로틀링: 5초 내에 같은 좌표로 호출되면 무시
+    const now = Date.now();
+    const lastCoords = lastCoordsRef.current;
+    const isSameCoords =
+      lastCoords &&
+      Math.abs(lastCoords.lat - lat) < 0.0001 &&
+      Math.abs(lastCoords.lng - lng) < 0.0001;
 
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
-        },
-      });
+    if (isSameCoords && now - lastCallTimeRef.current < 5000) {
+      if (isDev) console.log('🚫 같은 좌표로 너무 자주 호출됨, 무시');
+      return;
+    }
 
-      if (response.ok) {
-        const data = await response.json();
+    // 강화된 디바운싱: 2초 후에 실행
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_MAP_REST_API_KEY;
+        if (!KAKAO_REST_API_KEY) {
+          if (isDev) console.warn('Kakao REST API 키가 설정되지 않았습니다.');
+          setUserAddress('현재위치');
+          return;
+        }
 
-        if (data.documents && data.documents.length > 0) {
-          const roadAddress = data.documents[0].road_address?.address_name;
-          const bunjiAddress = data.documents[0].address?.address_name;
+        const x = lng.toString();
+        const y = lat.toString();
+        const url = `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${x}&y=${y}`;
 
-          // 도로명 주소가 있으면 도로명 주소를, 없으면 지번 주소를 사용
-          const finalAddress = roadAddress || bunjiAddress || '현재위치';
-          setUserAddress(finalAddress);
+        if (isDev) console.log('📍 주소 변환 API 호출:', { lat, lng });
+
+        const response = await fetch(url, {
+          headers: {
+            Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
+          },
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+
+          if (data.documents && data.documents.length > 0) {
+            const roadAddress = data.documents[0].road_address?.address_name;
+            const bunjiAddress = data.documents[0].address?.address_name;
+
+            // 도로명 주소가 있으면 도로명 주소를, 없으면 지번 주소를 사용
+            const finalAddress = roadAddress || bunjiAddress || '현재위치';
+            setUserAddress(finalAddress);
+          } else {
+            if (isDev) console.log('주소 정보가 없습니다.');
+            setUserAddress('현재위치');
+          }
         } else {
-          if (isDev) console.log('주소 정보가 없습니다.');
+          if (isDev) console.error('REST API 요청 실패:', response.status, response.statusText);
           setUserAddress('현재위치');
         }
-      } else {
-        if (isDev) console.error('REST API 요청 실패:', response.status, response.statusText);
+
+        // 성공한 호출 정보 저장
+        lastCallTimeRef.current = Date.now();
+        lastCoordsRef.current = { lat, lng };
+      } catch (error) {
+        if (isDev) console.error('주소 변환 실패:', error);
         setUserAddress('현재위치');
       }
-    } catch (error) {
-      if (isDev) console.error('주소 변환 실패:', error);
-      setUserAddress('현재위치');
-    }
+    }, 2000); // 2초 디바운싱으로 증가
   }, []);
 
   // GPS 위치 가져오기
@@ -107,17 +141,42 @@ export function useLocation(): UseLocationReturn {
     getCurrentLocation();
   }, [getCurrentLocation]);
 
-  // 초기 위치 가져오기
+  // 초기 위치 가져오기 (한 번만)
   useEffect(() => {
-    getCurrentLocation();
+    if (!isInitializedRef.current) {
+      isInitializedRef.current = true;
+      getCurrentLocation();
+    }
   }, [getCurrentLocation]);
 
-  // userLocation이 변경될 때마다 주소 변환 시도
+  // userLocation이 변경될 때마다 주소 변환 시도 (강화된 쓰로틀링 적용)
   useEffect(() => {
-    if (userLocation) {
+    if (userLocation && isInitializedRef.current) {
+      const now = Date.now();
+      const lastCoords = lastCoordsRef.current;
+      const isSameCoords =
+        lastCoords &&
+        Math.abs(lastCoords.lat - userLocation.lat) < 0.0001 &&
+        Math.abs(lastCoords.lng - userLocation.lng) < 0.0001;
+
+      // 같은 좌표이고 10초 내에 호출된 경우 무시
+      if (isSameCoords && now - lastCallTimeRef.current < 10000) {
+        if (isDev) console.log('🚫 같은 위치로 너무 자주 호출됨, 무시');
+        return;
+      }
+
       getAddressFromCoords(userLocation.lat, userLocation.lng);
     }
   }, [userLocation, getAddressFromCoords]);
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
 
   return {
     userLocation,

--- a/src/features/rental/map/hooks/useStoreListHooks.ts
+++ b/src/features/rental/map/hooks/useStoreListHooks.ts
@@ -85,6 +85,8 @@ export const convertToStoreCardProps = (storeList: StoreListItem[]): StoreCardPr
     store: {
       id: store.id,
       name: store.name,
+      leftDeviceCount: store.leftDeviceCount,
+      liked: store.liked,
       latitude: store.latitude,
       longititude: store.longititude,
     },
@@ -97,13 +99,13 @@ export const convertToStoreCardProps = (storeList: StoreListItem[]): StoreCardPr
       startTime: store.openTime,
       endTime: store.closeTime,
       storeName: store.name,
-      distanceFromMe: store.distanceFromMe, // 거리 정보 추가
-      name: store.name, // StoreDetail 타입에 name 필드 추가
+      distanceFromMe: store.distanceFromMe,
+      name: store.name,
     },
     deviceCount: store.leftDeviceCount,
     onLikeClick: () => {
       // 찜하기 기능 구현 필요
     },
-    isLiked: store.liked, // API에서 받은 liked 상태 사용
+    isLiked: store.liked,
   }));
 };

--- a/src/features/rental/map/lib/markerCache.ts
+++ b/src/features/rental/map/lib/markerCache.ts
@@ -183,12 +183,17 @@ export const updateMarkerLikeStatus = (storeId: number, isLiked: boolean): void 
 
 // 마커 이미지 생성 함수 (캐싱)
 const markerImageCache = new Map<string, kakao.maps.MarkerImage>();
+
+// 아이콘 경로를 가져오는 헬퍼 함수
+const getIconPath = (icon: string | { src: string }): string => {
+  return typeof icon === 'string' ? icon : icon.src;
+};
+
 export const createMarkerImage = (
   isLiked: boolean = false,
   isCluster: boolean = false,
 ): kakao.maps.MarkerImage => {
   let cacheKey: string;
-  let markerImageSrc: string;
 
   // 로그인 상태 확인
   const isLoggedIn =
@@ -200,26 +205,14 @@ export const createMarkerImage = (
   const shouldShowLikeActive = isLoggedIn && isLiked;
 
   if (isCluster) {
-    // 클러스터 마커 (줌 레벨 5 이상) - 좋아요 상태에 따라 아이콘 결정
     cacheKey = shouldShowLikeActive ? 'cluster_liked_marker' : 'cluster_default_marker';
-    markerImageSrc = shouldShowLikeActive
-      ? typeof ICONS.ETC.LIKE_ACTIVE === 'string'
-        ? ICONS.ETC.LIKE_ACTIVE
-        : ICONS.ETC.LIKE_ACTIVE.src
-      : typeof ICONS.ETC.LIKE_NONACTIVE === 'string'
-        ? ICONS.ETC.LIKE_NONACTIVE
-        : ICONS.ETC.LIKE_NONACTIVE.src;
   } else {
-    // 일반 마커 (줌 레벨 3 이하) - 좋아요 상태에 따라 아이콘 결정
     cacheKey = shouldShowLikeActive ? 'liked_marker' : 'default_marker';
-    markerImageSrc = shouldShowLikeActive
-      ? typeof ICONS.ETC.LIKE_ACTIVE === 'string'
-        ? ICONS.ETC.LIKE_ACTIVE
-        : ICONS.ETC.LIKE_ACTIVE.src
-      : typeof ICONS.ETC.LIKE_NONACTIVE === 'string'
-        ? ICONS.ETC.LIKE_NONACTIVE
-        : ICONS.ETC.LIKE_NONACTIVE.src;
   }
+
+  // 아이콘 선택 로직 단순화
+  const icon = shouldShowLikeActive ? ICONS.ETC.LIKE_ACTIVE : ICONS.ETC.LIKE_NONACTIVE;
+  const markerImageSrc = getIconPath(icon);
 
   if (markerImageCache.has(cacheKey)) {
     return markerImageCache.get(cacheKey)!;

--- a/src/features/rental/map/lib/markerCache.ts
+++ b/src/features/rental/map/lib/markerCache.ts
@@ -112,7 +112,7 @@ export class MarkerCache {
         markerData.marker.setImage(
           createMarkerImage(shouldShowLikeActive, isCluster ?? markerData.isCluster),
         );
-        if (isLiked !== undefined) markerData.isLiked = shouldShowLikeActive;
+        if (isLiked !== undefined) markerData.isLiked = isLiked;
         if (isCluster !== undefined) markerData.isCluster = isCluster;
       }
     }

--- a/src/features/rental/map/lib/renderStoreMarkers.ts
+++ b/src/features/rental/map/lib/renderStoreMarkers.ts
@@ -1,39 +1,9 @@
-import {
-  createMarkerImage,
-  MarkerCache,
-  markerCaches,
-  registerMarkerUpdateCallback,
-} from '@/features/rental/map/lib/markerCache';
+import { MarkerCache, markerCaches } from '@/features/rental/map/lib/markerCache';
 import { processBatch } from '@/features/rental/map/lib/markerCreator';
 import { debounce } from '@/features/rental/map/utils/debounceUtils';
 
 import type { Store, StoreDetail, StoreDevice } from '@/features/rental/map/lib/types';
 import type { RentalFilterState } from '@/features/rental/map/model/rentalFilterReducer';
-
-// 마커 업데이트 콜백 함수
-const createMarkerUpdateCallback = (map: kakao.maps.Map) => {
-  return (storeId: number, isLiked: boolean) => {
-    const cache = markerCaches.get(map);
-    if (cache && cache.hasMarker(storeId)) {
-      // 로그인 상태 확인
-      const isLoggedIn =
-        typeof window !== 'undefined' && localStorage.getItem('auth-storage')
-          ? JSON.parse(localStorage.getItem('auth-storage') || '{}').state?.isLoggedIn || false
-          : false;
-
-      // 좋아요 상태 결정: 로그인한 사용자이고 liked가 true인 경우에만 like_active 표시
-      const shouldShowLikeActive = isLoggedIn && isLiked;
-
-      // 마커 데이터 가져오기
-      const markerData = cache.getMarkerData(storeId);
-      if (markerData) {
-        // 마커 이미지 업데이트
-        markerData.marker.setImage(createMarkerImage(shouldShowLikeActive, markerData.isCluster));
-        markerData.isLiked = shouldShowLikeActive;
-      }
-    }
-  };
-};
 
 // 마커 렌더링 함수 (디바운싱 적용)
 const debouncedRenderMarkers = debounce(
@@ -54,10 +24,6 @@ const debouncedRenderMarkers = debounce(
         cache = new MarkerCache(map);
         markerCaches.set(map, cache);
       }
-
-      // 마커 업데이트 콜백 등록 (한 번만 등록)
-      const markerUpdateCallback = createMarkerUpdateCallback(map);
-      registerMarkerUpdateCallback(markerUpdateCallback);
 
       // 현재 스토어 ID들
       const currentStoreIds = new Set(stores.map((store) => store.id));

--- a/src/features/rental/map/lib/types.ts
+++ b/src/features/rental/map/lib/types.ts
@@ -40,6 +40,7 @@ export interface StoreCardProps {
   storeDetail: StoreDetail;
   deviceCount: number;
   onLikeClick?: () => void;
+  onLikeToggle?: (storeId: number, isLiked: boolean) => void;
   isLiked?: boolean;
   className?: string;
 }

--- a/src/features/rental/map/lib/types.ts
+++ b/src/features/rental/map/lib/types.ts
@@ -6,7 +6,49 @@ export interface Store {
   name: string;
   latitude: number;
   longititude: number;
+  leftDeviceCount: number;
+  liked: boolean;
+  isCluster?: boolean; // 클러스터 여부
 }
+
+/*
+  지도 API 응답 - 줌 레벨 3 이하 (개별 가맹점)
+*/
+export interface MapStoreResponse {
+  id: number;
+  longititude: number;
+  latitude: number;
+  name: string;
+  leftDeviceCount: number;
+  liked: boolean;
+}
+
+/*
+  지도 API 응답 - 줌 레벨 4 이상 (클러스터링)
+*/
+export interface MapClusterResponse {
+  id: number; // 클러스터링 아이디 (의미 없는 데이터)
+  longititude: number; // 클러스터링된 위경도 중심값
+  latitude: number; // 클러스터링된 위경도 중심값
+  name: null; // 이름은 의미가 없어서 null로 전달
+  leftDeviceCount: number; // 클러스터링 내에 조건에 맞는 남은 갯수
+  liked: boolean; // 클러스터 내 좋아요 상태 (true/false)
+}
+
+/*
+  지도 API 공통 응답 타입
+*/
+export type MapStoreItem = MapStoreResponse | MapClusterResponse;
+
+/*
+  지도 API 응답
+*/
+export interface MapStoresResponse {
+  code: number;
+  message: string | null;
+  content: MapStoreItem[];
+}
+
 /*
   가맹점 장비 정보
 */
@@ -129,7 +171,7 @@ export interface StoreDetail {
 }
 
 /*
-  가맹점 목록 리스트 파라미터
+  지도 가맹점 목록 조회 파라미터
 */
 export interface FetchStoresParams {
   // 지도 영역 좌표
@@ -139,6 +181,7 @@ export interface FetchStoresParams {
   neLng?: number;
 
   // 필터 조건
+  isOpeningNow?: boolean;
   rentalStartDate?: string;
   rentalEndDate?: string;
   reviewRating?: number;
@@ -147,6 +190,7 @@ export interface FetchStoresParams {
   dataCapacity?: number[];
   is5G?: boolean;
   maxSupportConnection?: number[];
+  zoomLevel?: number; // 줌 레벨 추가
 }
 
 /*

--- a/src/features/rental/map/ui/DragBottomSheet.tsx
+++ b/src/features/rental/map/ui/DragBottomSheet.tsx
@@ -36,6 +36,8 @@ export const DragBottomSheet = ({
 }: ExtendedDragBottomSheetProps) => {
   const [windowHeight, setWindowHeight] = useState(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [animatedItems, setAnimatedItems] = useState<Set<string>>(new Set());
+  const [lastStoreCount, setLastStoreCount] = useState(0);
 
   // 무한 스크롤 핸들러
   const handleScroll = useCallback(() => {
@@ -48,6 +50,23 @@ export const DragBottomSheet = ({
       onLoadMore();
     }
   }, [onLoadMore, isFetchingNextPage, hasNextPage]);
+
+  // 새로 로드된 아이템들을 추적하여 애니메이션 적용
+  useEffect(() => {
+    if (storeList && storeList.length > lastStoreCount) {
+      const newItems = storeList.slice(lastStoreCount);
+      const newAnimatedItems = new Set(animatedItems);
+
+      // 새로 로드된 아이템들을 애니메이션 대상으로 추가
+      newItems.forEach((store, index) => {
+        const itemKey = `${store.id || `item-${lastStoreCount + index}`}`;
+        newAnimatedItems.add(itemKey);
+      });
+
+      setAnimatedItems(newAnimatedItems);
+      setLastStoreCount(storeList.length);
+    }
+  }, [storeList, lastStoreCount, animatedItems]);
 
   // windowHeight가 설정된 후에 계산하도록 수정
   const expandedY = windowHeight > 0 ? 60 : 0; // header 높이
@@ -156,11 +175,14 @@ export const DragBottomSheet = ({
       >
         {isLoading ? (
           <div className="flex flex-col items-center gap-3 px-4 pt-3 pb-6">
-            <div className="text-center text-gray-500">스토어 목록을 불러오는 중...</div>
+            <div className="text-center text-[var(--gray-dark)] animate-pulse">
+              <div className="loading-spinner mr-2"></div>
+              스토어 목록을 불러오는 중...
+            </div>
           </div>
         ) : isError ? (
           <div className="flex flex-col items-center gap-3 px-4 pt-3 pb-6">
-            <div className="text-center text-red-500">
+            <div className="text-center text-[var(--red-main)] animate-fade-in">
               에러가 발생했습니다: {error?.message || '알 수 없는 오류'}
             </div>
           </div>
@@ -169,25 +191,46 @@ export const DragBottomSheet = ({
             {(() => {
               return null;
             })()}
-            {storeList.map((store, idx) => (
-              <StoreCard key={store.id || idx} {...store} />
-            ))}
+            {storeList.map((store, idx) => {
+              const itemKey = `${store.id || `item-${idx}`}`;
+              const isNewItem = animatedItems.has(itemKey);
+              const isInitialLoad = idx < 5; // 초기 로드된 아이템들
+
+              // 초기 로드된 아이템들은 순차 애니메이션, 새로 로드된 아이템들은 즉시 애니메이션
+              const staggerClass = isInitialLoad
+                ? `animate-stagger-${Math.min(idx + 1, 5)}`
+                : 'animate-slide-in-up';
+
+              // 새로 로드된 아이템들은 즉시 애니메이션 적용
+              const animationClass =
+                isNewItem && !isInitialLoad
+                  ? 'animate-slide-in-up animate-fade-in'
+                  : `animate-slide-in-up ${staggerClass}`;
+
+              return (
+                <div key={itemKey} className={`w-full ${animationClass}`}>
+                  <StoreCard {...store} />
+                </div>
+              );
+            })}
             {/* 무한 스크롤 로딩 인디케이터 */}
             {isFetchingNextPage && (
-              <div className="text-center text-[var(--gray-dark)] py-4">
-                더 많은 스토어를 불러오는 중...
+              <div className="text-center text-[var(--gray-dark)] py-4 animate-fade-in">
+                <div className="loading-spinner mr-2"></div>더 많은 스토어를 불러오는 중...
               </div>
             )}
             {/* 더 이상 데이터가 없을 때 */}
             {!hasNextPage && storeList.length > 0 && (
-              <div className="text-center text-[var(--gray-dark)] py-4">
+              <div className="text-center text-[var(--gray-dark)] py-4 animate-fade-in">
                 모든 스토어를 불러왔습니다.
               </div>
             )}
           </div>
         ) : (
           <div className="flex flex-col gap-3 px-4 pt-3 pb-6">
-            <div className="text-center text-[var(--gray-dark)]">표시할 스토어가 없습니다.</div>
+            <div className="text-center text-[var(--gray-dark)] animate-fade-in">
+              표시할 스토어가 없습니다.
+            </div>
             {children}
           </div>
         )}

--- a/src/features/rental/map/ui/MapSection.tsx
+++ b/src/features/rental/map/ui/MapSection.tsx
@@ -27,6 +27,7 @@ export const MapSection = ({ filterState, onStoreMarkerClick, onMapReady }: MapS
 
   const lastStoresRef = useRef<Store[]>([]);
   const lastFilterStateRef = useRef<RentalFilterState>(filterState);
+  const isMapReadyRef = useRef(false);
 
   // 디바운스된 마커 렌더링 함수
   const debouncedRenderMarkers = useMemo(
@@ -42,7 +43,9 @@ export const MapSection = ({ filterState, onStoreMarkerClick, onMapReady }: MapS
             storeId?: number,
           ) => void,
         ) => {
+          console.log('🎨 마커 렌더링 시작:', { storesCount: stores.length });
           await renderStoreMarkers(map, stores, filterState, onStoreMarkerClick);
+          console.log('✅ 마커 렌더링 완료');
         },
         200,
       ),
@@ -51,9 +54,10 @@ export const MapSection = ({ filterState, onStoreMarkerClick, onMapReady }: MapS
 
   // 마커 렌더링 함수를 메모이제이션
   const renderMarkers = useCallback(async () => {
-    if (!map) return;
+    if (!map) {
+      return;
+    }
 
-    // 디바운스된 렌더링 함수 호출
     debouncedRenderMarkers(map, stores, filterState, onStoreMarkerClick);
   }, [map, stores, filterState, onStoreMarkerClick, debouncedRenderMarkers]);
 
@@ -62,6 +66,11 @@ export const MapSection = ({ filterState, onStoreMarkerClick, onMapReady }: MapS
     const storesChanged = JSON.stringify(stores) !== JSON.stringify(lastStoresRef.current);
     const filterChanged =
       JSON.stringify(filterState) !== JSON.stringify(lastFilterStateRef.current);
+
+    // 맵이 준비되지 않았으면 렌더링하지 않음
+    if (!isMapReadyRef.current) {
+      return false;
+    }
 
     if (storesChanged || filterChanged) {
       lastStoresRef.current = stores;
@@ -74,13 +83,16 @@ export const MapSection = ({ filterState, onStoreMarkerClick, onMapReady }: MapS
   // 마커 렌더링 효과
   useEffect(() => {
     if (shouldRenderMarkers) {
+      console.log('🎯 마커 렌더링 실행');
       renderMarkers();
     }
   }, [shouldRenderMarkers, renderMarkers]);
 
-  // 맵 준비 완료 시 콜백 호출
+  // 맵 준비 완료 시 콜백 호출 및 플래그 설정
   useEffect(() => {
     if (map && onMapReady) {
+      console.log('🗺️ 맵 준비 완료');
+      isMapReadyRef.current = true;
       onMapReady(map);
     }
   }, [map, onMapReady]);

--- a/src/features/rental/map/ui/StoreCard.tsx
+++ b/src/features/rental/map/ui/StoreCard.tsx
@@ -1,15 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
-import Image from 'next/image';
-
-import { useAuthStore } from '@/entities/auth/model/authStore';
-import { toggleStoreLike } from '@/features/rental/map/api/apis';
-import { ICONS } from '@/shared/config/iconPath';
+import { useStoreLikeToggle } from '@/shared/hooks/useStoreLikeToggle';
 import { formatDistanceString } from '@/shared/lib/format/distanceUtils';
-import { makeToast } from '@/shared/lib/makeToast';
 import { ImageBox } from '@/shared/ui/ImageBox';
+import { StoreLikeButton } from '@/shared/ui/StoreLikeButton';
 
 import type { StoreCardProps } from '@/features/rental/map/lib/types';
 
@@ -20,61 +16,32 @@ export function StoreCard({
   store,
   storeDetail,
   deviceCount,
-  onLikeClick,
   onLikeToggle,
   isLiked = false,
   className,
   showDistance = true,
 }: StoreCardProps & { showDistance?: boolean }) {
-  const { isLoggedIn } = useAuthStore();
-  const [liked, setLiked] = useState(isLiked);
-  const [isLikeLoading, setIsLikeLoading] = useState(false);
-  const operatingStatus = storeDetail.isOpening ? '영업 중' : '영업 종료';
+  const {
+    isLoading: isLikeLoading,
+    shouldShowLikeActive,
+    handleLikeToggle,
+    setLiked,
+  } = useStoreLikeToggle({
+    storeId: store.id,
+    initialIsLiked: isLiked,
+    onToggle: onLikeToggle,
+  });
 
   // isLiked prop이 변경될 때 liked 상태 업데이트
   useEffect(() => {
     setLiked(isLiked);
-  }, [isLiked]);
+  }, [isLiked, setLiked]);
 
-  // 로그인하지 않은 사용자는 항상 like_nonactive 표시
-  const shouldShowLikeActive = isLoggedIn && liked;
-
-  // 좋아요 토글 핸들러
-  const handleLikeToggle = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-
-    // 로그인하지 않은 사용자는 좋아요 기능 비활성화
-    if (!isLoggedIn) {
-      makeToast('로그인이 필요한 서비스입니다.', 'warning');
-      return;
-    }
-
-    if (isLikeLoading) return;
-
-    try {
-      setIsLikeLoading(true);
-      // 현재 상태를 기반으로 API 호출 (liked가 true면 좋아요 취소, false면 좋아요 추가)
-      await toggleStoreLike(store.id, liked);
-
-      const newLikedState = !liked;
-      setLiked(newLikedState);
-
-      // 기존 onLikeToggle이나 onLikeClick 콜백 호출
-      if (onLikeToggle) {
-        onLikeToggle(store.id, newLikedState);
-      } else if (onLikeClick) {
-        onLikeClick();
-      }
-    } catch (error) {
-      console.error('StoreCard 좋아요 토글 실패:', error);
-    } finally {
-      setIsLikeLoading(false);
-    }
-  };
+  const operatingStatus = storeDetail.isOpening ? '영업 중' : '영업 종료';
 
   return (
     <div
-      className={`w-[380px] bg-[var(--white)] rounded-[16px] p-3 flex gap-3 shadow-sm relative items-start ${className ?? ''}`}
+      className={`w-[380px] bg-white rounded-[16px] p-3 flex gap-3 shadow-sm relative items-start ${className ?? ''}`}
     >
       {/* 왼쪽: 스토어 이미지 */}
       <ImageBox
@@ -84,9 +51,9 @@ export function StoreCard({
       {/* 중앙: content 영역 */}
       <div className="flex flex-col flex-1 h-[68px] justify-between min-w-0">
         {/* 타이틀: 상단 고정 - 길면 ... 처리 */}
-        <h3 className="text-[var(--black)] font-small-regular truncate">{store.name}</h3>
+        <h3 className="text-black font-small-regular truncate">{store.name}</h3>
         {/* 영업 상태 및 시간: 가운데 */}
-        <p className="font-small-regular text-[var(--black)] truncate">
+        <p className="font-small-regular text-black truncate">
           {operatingStatus} · {formatTime(storeDetail.startTime)} ~{' '}
           {formatTime(storeDetail.endTime)}
         </p>
@@ -102,37 +69,19 @@ export function StoreCard({
               {storeDetail.detailAddress}
             </span>
           </div>
-          <div className="font-small-medium text-[var(--black)] flex items-end flex-shrink-0">
+          <div className="font-small-medium text-black flex items-end flex-shrink-0">
             남은 공유기&nbsp;<span className="text-[var(--main-5)]">{deviceCount}대</span>
           </div>
         </div>
       </div>
       {/* 오른쪽 상단 좋아요 버튼 */}
       <div className="absolute right-3 top-3">
-        <div className="rounded-full bg-[var(--white)] flex items-center justify-center w-6 h-6 shadow-lg">
-          <button
-            type="button"
-            onClick={handleLikeToggle}
-            disabled={isLikeLoading}
-            className="cursor-pointer p-0 border-none rounded-full flex items-center justify-center min-w-0 min-h-0 w-[21px] h-[21px]"
-          >
-            <Image
-              src={
-                shouldShowLikeActive
-                  ? typeof ICONS.ETC.LIKE_ACTIVE === 'string'
-                    ? ICONS.ETC.LIKE_ACTIVE
-                    : ICONS.ETC.LIKE_ACTIVE.src
-                  : typeof ICONS.ETC.LIKE_NONACTIVE === 'string'
-                    ? ICONS.ETC.LIKE_NONACTIVE
-                    : ICONS.ETC.LIKE_NONACTIVE.src
-              }
-              alt={shouldShowLikeActive ? '좋아요 활성' : '좋아요 비활성'}
-              width={21}
-              height={21}
-              className={isLikeLoading ? 'opacity-50' : ''}
-            />
-          </button>
-        </div>
+        <StoreLikeButton
+          isLiked={shouldShowLikeActive}
+          isLoading={isLikeLoading}
+          onClick={handleLikeToggle}
+          size="sm"
+        />
       </div>
     </div>
   );

--- a/src/features/rental/map/ui/StoreCard.tsx
+++ b/src/features/rental/map/ui/StoreCard.tsx
@@ -20,7 +20,8 @@ export function StoreCard({
   isLiked = false,
   className,
   showDistance = true,
-}: StoreCardProps & { showDistance?: boolean }) {
+  disableToast = false,
+}: StoreCardProps & { showDistance?: boolean; disableToast?: boolean }) {
   const {
     isLoading: isLikeLoading,
     shouldShowLikeActive,
@@ -30,6 +31,7 @@ export function StoreCard({
     storeId: store.id,
     initialIsLiked: isLiked,
     onToggle: onLikeToggle,
+    disableToast,
   });
 
   // isLiked prop이 변경될 때 liked 상태 업데이트

--- a/src/features/rental/map/ui/StoreCard.tsx
+++ b/src/features/rental/map/ui/StoreCard.tsx
@@ -1,8 +1,15 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
+import Image from 'next/image';
+
+import { useAuthStore } from '@/entities/auth/model/authStore';
+import { toggleStoreLike } from '@/features/rental/map/api/apis';
+import { ICONS } from '@/shared/config/iconPath';
 import { formatDistanceString } from '@/shared/lib/format/distanceUtils';
+import { makeToast } from '@/shared/lib/makeToast';
 import { ImageBox } from '@/shared/ui/ImageBox';
-import { LikeButtonCircle } from '@/shared/ui/LikeButtonCircle/LikeButtonCircle';
 
 import type { StoreCardProps } from '@/features/rental/map/lib/types';
 
@@ -14,15 +21,60 @@ export function StoreCard({
   storeDetail,
   deviceCount,
   onLikeClick,
+  onLikeToggle,
   isLiked = false,
   className,
   showDistance = true,
 }: StoreCardProps & { showDistance?: boolean }) {
+  const { isLoggedIn } = useAuthStore();
+  const [liked, setLiked] = useState(isLiked);
+  const [isLikeLoading, setIsLikeLoading] = useState(false);
   const operatingStatus = storeDetail.isOpening ? '영업 중' : '영업 종료';
+
+  // isLiked prop이 변경될 때 liked 상태 업데이트
+  useEffect(() => {
+    setLiked(isLiked);
+  }, [isLiked]);
+
+  // 로그인하지 않은 사용자는 항상 like_nonactive 표시
+  const shouldShowLikeActive = isLoggedIn && liked;
+
+  // 좋아요 토글 핸들러
+  const handleLikeToggle = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    // 로그인하지 않은 사용자는 좋아요 기능 비활성화
+    if (!isLoggedIn) {
+      makeToast('로그인이 필요한 서비스입니다.', 'warning');
+      return;
+    }
+
+    if (isLikeLoading) return;
+
+    try {
+      setIsLikeLoading(true);
+      // 현재 상태를 기반으로 API 호출 (liked가 true면 좋아요 취소, false면 좋아요 추가)
+      await toggleStoreLike(store.id, liked);
+
+      const newLikedState = !liked;
+      setLiked(newLikedState);
+
+      // 기존 onLikeToggle이나 onLikeClick 콜백 호출
+      if (onLikeToggle) {
+        onLikeToggle(store.id, newLikedState);
+      } else if (onLikeClick) {
+        onLikeClick();
+      }
+    } catch (error) {
+      console.error('StoreCard 좋아요 토글 실패:', error);
+    } finally {
+      setIsLikeLoading(false);
+    }
+  };
 
   return (
     <div
-      className={`w-[380px] bg-white rounded-[16px] p-3 flex gap-3 shadow-sm relative items-start ${className ?? ''}`}
+      className={`w-[380px] bg-[var(--white)] rounded-[16px] p-3 flex gap-3 shadow-sm relative items-start ${className ?? ''}`}
     >
       {/* 왼쪽: 스토어 이미지 */}
       <ImageBox
@@ -32,9 +84,9 @@ export function StoreCard({
       {/* 중앙: content 영역 */}
       <div className="flex flex-col flex-1 h-[68px] justify-between min-w-0">
         {/* 타이틀: 상단 고정 - 길면 ... 처리 */}
-        <h3 className="text-black font-small-regular truncate">{store.name}</h3>
+        <h3 className="text-[var(--black)] font-small-regular truncate">{store.name}</h3>
         {/* 영업 상태 및 시간: 가운데 */}
-        <p className="font-small-regular text-black truncate">
+        <p className="font-small-regular text-[var(--black)] truncate">
           {operatingStatus} · {formatTime(storeDetail.startTime)} ~{' '}
           {formatTime(storeDetail.endTime)}
         </p>
@@ -50,19 +102,38 @@ export function StoreCard({
               {storeDetail.detailAddress}
             </span>
           </div>
-          <div className="font-small-medium text-black flex items-end flex-shrink-0">
+          <div className="font-small-medium text-[var(--black)] flex items-end flex-shrink-0">
             남은 공유기&nbsp;<span className="text-[var(--main-5)]">{deviceCount}대</span>
           </div>
         </div>
       </div>
-      {/* 오른쪽 상단 LikeButtonCircle */}
-      <LikeButtonCircle
-        active={isLiked}
-        onClick={onLikeClick}
-        size="sm"
-        shadow
-        className="absolute right-3 top-3"
-      />
+      {/* 오른쪽 상단 좋아요 버튼 */}
+      <div className="absolute right-3 top-3">
+        <div className="rounded-full bg-[var(--white)] flex items-center justify-center w-6 h-6 shadow-lg">
+          <button
+            type="button"
+            onClick={handleLikeToggle}
+            disabled={isLikeLoading}
+            className="cursor-pointer p-0 border-none rounded-full flex items-center justify-center min-w-0 min-h-0 w-[21px] h-[21px]"
+          >
+            <Image
+              src={
+                shouldShowLikeActive
+                  ? typeof ICONS.ETC.LIKE_ACTIVE === 'string'
+                    ? ICONS.ETC.LIKE_ACTIVE
+                    : ICONS.ETC.LIKE_ACTIVE.src
+                  : typeof ICONS.ETC.LIKE_NONACTIVE === 'string'
+                    ? ICONS.ETC.LIKE_NONACTIVE
+                    : ICONS.ETC.LIKE_NONACTIVE.src
+              }
+              alt={shouldShowLikeActive ? '좋아요 활성' : '좋아요 비활성'}
+              width={21}
+              height={21}
+              className={isLikeLoading ? 'opacity-50' : ''}
+            />
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/features/rental/map/ui/StoreCard.tsx
+++ b/src/features/rental/map/ui/StoreCard.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
-
 import { useStoreLikeToggle } from '@/shared/hooks/useStoreLikeToggle';
 import { formatDistanceString } from '@/shared/lib/format/distanceUtils';
 import { ImageBox } from '@/shared/ui/ImageBox';
@@ -26,18 +24,12 @@ export function StoreCard({
     isLoading: isLikeLoading,
     shouldShowLikeActive,
     handleLikeToggle,
-    setLiked,
   } = useStoreLikeToggle({
     storeId: store.id,
     initialIsLiked: isLiked,
     onToggle: onLikeToggle,
     disableToast,
   });
-
-  // isLiked prop이 변경될 때 liked 상태 업데이트
-  useEffect(() => {
-    setLiked(isLiked);
-  }, [isLiked, setLiked]);
 
   const operatingStatus = storeDetail.isOpening ? '영업 중' : '영업 종료';
 

--- a/src/features/rental/map/utils/filterParamsMapper.ts
+++ b/src/features/rental/map/utils/filterParamsMapper.ts
@@ -12,11 +12,24 @@ interface BoundsType {
 export const mapFilterStateToApiParams = (
   bounds: BoundsType,
   filterState?: RentalFilterState,
+  zoomLevel?: number,
 ): Record<string, unknown> => {
   const mergedParams: Record<string, unknown> = { ...bounds };
 
+  // zoomLevel 추가
+  if (zoomLevel !== undefined) {
+    mergedParams.zoomLevel = zoomLevel;
+  }
+
+  // filterState가 없으면 기본 필터 값들을 추가하지 않음 (초기 로드)
   if (!filterState) {
     return mergedParams;
+  }
+
+  // filterState가 있을 때만 필터 조건들 추가
+  // 오픈 여부
+  if ('isOpeningNow' in filterState && filterState.isOpeningNow !== undefined) {
+    mergedParams.isOpeningNow = filterState.isOpeningNow;
   }
 
   // 가격
@@ -42,7 +55,7 @@ export const mapFilterStateToApiParams = (
   if (filterState.dataAmount && filterState.dataAmount !== '무제한') {
     mergedParams.dataCapacity = [parseInt(filterState.dataAmount.replace('GB', ''))];
   } else if (filterState.dataAmount === '무제한') {
-    mergedParams.dataCapacity = [99999]; // 백엔드와 협의된 값 사용
+    mergedParams.dataCapacity = [999]; // 백엔드와 협의된 값 사용
   }
   // 데이터 타입 (dataType → is5G)
   if (filterState.dataType === '5G') {
@@ -60,10 +73,6 @@ export const mapFilterStateToApiParams = (
   }
   if (filterState.dateRange?.to) {
     mergedParams.rentalEndDate = formatDateToLocalDateTime(filterState.dateRange.to);
-  }
-  // 오픈 여부
-  if ('isOpeningNow' in filterState && filterState.isOpeningNow !== undefined) {
-    mergedParams.isOpeningNow = filterState.isOpeningNow;
   }
 
   return mergedParams;

--- a/src/features/rental/map/utils/storeDataMapper.ts
+++ b/src/features/rental/map/utils/storeDataMapper.ts
@@ -13,6 +13,8 @@ export const transformStoreResponseToStoreCard = (
       name: storeResponse.name,
       latitude: storeResponse.latitude,
       longititude: storeResponse.longititude,
+      leftDeviceCount: storeResponse.leftDeviceCount,
+      liked: storeResponse.liked,
     },
     storeDetail: {
       storeId: storeResponse.id,

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -48,6 +48,7 @@ export const END_POINTS = {
     AVAILABLE_DEVICE: (storeId: number) => `/api/v1/rentals/${storeId}/devices`, //예약할 기기 조회
     RESERVATIONS: `/api/v1/rentals/devices`,
     RESTOCK: `/api/v1/restock`,
+    RENTAL_CANCEL: (restockId: number) => `/api/v1/restock/${restockId}`,
     RESERVATION_DETAILS: (reservationId: number) =>
       `/api/v1/rentals/reservations/${reservationId}/devices`,
   },

--- a/src/shared/hooks/useStoreLikeToggle.ts
+++ b/src/shared/hooks/useStoreLikeToggle.ts
@@ -8,12 +8,14 @@ interface UseStoreLikeToggleProps {
   storeId: number;
   initialIsLiked?: boolean;
   onToggle?: (storeId: number, isLiked: boolean) => void;
+  disableToast?: boolean; // 토스트 메시지 비활성화 옵션
 }
 
 export const useStoreLikeToggle = ({
   storeId,
   initialIsLiked = false,
   onToggle,
+  disableToast = false,
 }: UseStoreLikeToggleProps) => {
   const { isLoggedIn } = useAuthStore();
   const [liked, setLiked] = useState(initialIsLiked);
@@ -42,6 +44,14 @@ export const useStoreLikeToggle = ({
         const newLikedState = !liked;
         setLiked(newLikedState);
 
+        // 토스트 메시지 비활성화가 아닌 경우에만 표시
+        if (!disableToast) {
+          makeToast(
+            newLikedState ? '좋아요가 추가되었습니다.' : '좋아요가 취소되었습니다.',
+            'success',
+          );
+        }
+
         // 콜백 함수 호출
         onToggle?.(storeId, newLikedState);
       } catch (error) {
@@ -51,7 +61,7 @@ export const useStoreLikeToggle = ({
         setIsLoading(false);
       }
     },
-    [storeId, liked, isLoading, isLoggedIn, onToggle],
+    [storeId, liked, isLoading, isLoggedIn, onToggle, disableToast],
   );
 
   // 로그인하지 않은 사용자는 항상 like_nonactive 표시

--- a/src/shared/hooks/useStoreLikeToggle.ts
+++ b/src/shared/hooks/useStoreLikeToggle.ts
@@ -1,26 +1,31 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { useAuthStore } from '@/entities/auth/model/authStore';
 import { toggleStoreLike } from '@/features/rental/map/api/apis';
 import { updateMarkerLikeStatus } from '@/features/rental/map/lib/markerCache';
 import { makeToast } from '@/shared/lib/makeToast';
 
-interface UseStoreLikeToggleProps {
+export interface UseStoreLikeToggleProps {
   storeId: number;
-  initialIsLiked?: boolean;
+  initialIsLiked: boolean;
   onToggle?: (storeId: number, isLiked: boolean) => void;
-  disableToast?: boolean; // 토스트 메시지 비활성화 옵션
+  disableToast?: boolean;
 }
 
 export const useStoreLikeToggle = ({
   storeId,
-  initialIsLiked = false,
+  initialIsLiked,
   onToggle,
   disableToast = false,
 }: UseStoreLikeToggleProps) => {
-  const { isLoggedIn } = useAuthStore();
   const [liked, setLiked] = useState(initialIsLiked);
   const [isLoading, setIsLoading] = useState(false);
+  const { isLoggedIn } = useAuthStore();
+
+  // 동시성 제어를 위한 AbortController
+  const abortControllerRef = useRef<AbortController | null>(null);
+  // 이전 상태 추적을 위한 ref
+  const previousLikedRef = useRef(initialIsLiked);
 
   const handleLikeToggle = useCallback(
     async (e?: React.MouseEvent) => {
@@ -35,10 +40,17 @@ export const useStoreLikeToggle = ({
         return;
       }
 
-      if (isLoading) return;
+      // 이전 요청 취소
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
 
       try {
+        abortControllerRef.current = new AbortController();
         setIsLoading(true);
+
+        // 현재 상태 저장
+        previousLikedRef.current = liked;
 
         // 낙관적 업데이트: 즉시 UI 상태 변경
         const newLikedState = !liked;
@@ -48,7 +60,7 @@ export const useStoreLikeToggle = ({
         updateMarkerLikeStatus(storeId, newLikedState);
 
         // API 호출
-        await toggleStoreLike(storeId, liked);
+        await toggleStoreLike(storeId, liked, abortControllerRef.current.signal);
 
         // 토스트 메시지 비활성화가 아닌 경우에만 표시
         if (!disableToast) {
@@ -61,28 +73,36 @@ export const useStoreLikeToggle = ({
         // 콜백 함수 호출
         onToggle?.(storeId, newLikedState);
       } catch (error) {
+        // AbortError는 무시 (사용자가 취소한 경우)
+        if (error instanceof Error && error.name === 'AbortError') {
+          return;
+        }
+
         console.error('가맹점 좋아요 토글 실패:', error);
 
         // 에러 발생 시 원래 상태로 롤백
-        setLiked(liked);
-        updateMarkerLikeStatus(storeId, liked);
+        setLiked(previousLikedRef.current);
+        updateMarkerLikeStatus(storeId, previousLikedRef.current);
 
         makeToast('좋아요 처리 중 오류가 발생했습니다.', 'warning');
       } finally {
         setIsLoading(false);
+        abortControllerRef.current = null;
       }
     },
-    [storeId, liked, isLoading, isLoggedIn, onToggle, disableToast],
+    [storeId, liked, isLoggedIn, onToggle, disableToast],
   );
 
-  // 로그인하지 않은 사용자는 항상 like_nonactive 표시
-  const shouldShowLikeActive = isLoggedIn && liked;
+  // 초기 상태가 변경되면 ref도 업데이트
+  if (previousLikedRef.current !== initialIsLiked) {
+    previousLikedRef.current = initialIsLiked;
+  }
 
   return {
     liked,
     isLoading,
-    shouldShowLikeActive,
+    shouldShowLikeActive: isLoggedIn && liked,
     handleLikeToggle,
-    setLiked, // 외부에서 상태 업데이트가 필요한 경우
+    setLiked,
   };
 };

--- a/src/shared/hooks/useStoreLikeToggle.ts
+++ b/src/shared/hooks/useStoreLikeToggle.ts
@@ -1,0 +1,67 @@
+import { useCallback, useState } from 'react';
+
+import { useAuthStore } from '@/entities/auth/model/authStore';
+import { toggleStoreLike } from '@/features/rental/map/api/apis';
+import { makeToast } from '@/shared/lib/makeToast';
+
+interface UseStoreLikeToggleProps {
+  storeId: number;
+  initialIsLiked?: boolean;
+  onToggle?: (storeId: number, isLiked: boolean) => void;
+}
+
+export const useStoreLikeToggle = ({
+  storeId,
+  initialIsLiked = false,
+  onToggle,
+}: UseStoreLikeToggleProps) => {
+  const { isLoggedIn } = useAuthStore();
+  const [liked, setLiked] = useState(initialIsLiked);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLikeToggle = useCallback(
+    async (e?: React.MouseEvent) => {
+      // 이벤트 전파 방지
+      if (e) {
+        e.stopPropagation();
+      }
+
+      // 로그인하지 않은 사용자는 좋아요 기능 비활성화
+      if (!isLoggedIn) {
+        makeToast('로그인이 필요한 서비스입니다.', 'warning');
+        return;
+      }
+
+      if (isLoading) return;
+
+      try {
+        setIsLoading(true);
+
+        await toggleStoreLike(storeId, liked);
+
+        const newLikedState = !liked;
+        setLiked(newLikedState);
+
+        // 콜백 함수 호출
+        onToggle?.(storeId, newLikedState);
+      } catch (error) {
+        console.error('가맹점 좋아요 토글 실패:', error);
+        makeToast('좋아요 처리 중 오류가 발생했습니다.', 'warning');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [storeId, liked, isLoading, isLoggedIn, onToggle],
+  );
+
+  // 로그인하지 않은 사용자는 항상 like_nonactive 표시
+  const shouldShowLikeActive = isLoggedIn && liked;
+
+  return {
+    liked,
+    isLoading,
+    shouldShowLikeActive,
+    handleLikeToggle,
+    setLiked, // 외부에서 상태 업데이트가 필요한 경우
+  };
+};

--- a/src/shared/lib/utils/storeIsOpeningUtils.ts
+++ b/src/shared/lib/utils/storeIsOpeningUtils.ts
@@ -1,0 +1,14 @@
+/**
+ * 영업 상태 확인 함수 (한국 시간 기준)
+ * @param startTime - 시작 시간 (HH:mm:ss 형식)
+ * @param endTime - 종료 시간 (HH:mm:ss 형식)
+ * @returns 영업 중이면 true, 아니면 false
+ */
+export const isStoreOpen = (startTime: string, endTime: string): boolean => {
+  const now = new Date();
+  // 브라우저가 이미 한국 시간으로 설정되어 있으므로 현재 시간을 그대로 사용
+  const currentTimeString = now.toTimeString().split(' ')[0];
+  // startTime과 endTime을 비교
+  const isOpen = currentTimeString >= startTime && currentTimeString <= endTime;
+  return isOpen;
+};

--- a/src/shared/styles/index.css
+++ b/src/shared/styles/index.css
@@ -1,2 +1,3 @@
 @import 'tailwindcss/preflight';
 @import 'tailwindcss/utilities';
+@import './list-animations.css';

--- a/src/shared/styles/list-animations.css
+++ b/src/shared/styles/list-animations.css
@@ -42,6 +42,30 @@
   }
 }
 
+@keyframes slide-in-down {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(100%) scale(0.95);
+  }
+}
+
+@keyframes slide-out-down {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    height: auto;
+  }
+  to {
+    opacity: 0;
+    transform: translateY(100%) scale(0.8);
+    height: 0;
+  }
+}
+
 /* Animation Classes */
 .animate-fade-in {
   animation: fade-in 0.5s ease-out;
@@ -49,6 +73,14 @@
 
 .animate-slide-in-up {
   animation: slide-in-up 0.6s ease-out;
+}
+
+.animate-slide-out-down {
+  animation: slide-out-down 0.5s ease-out;
+}
+
+.animate-slide-in-down {
+  animation: slide-in-down 0.4s ease-out;
 }
 
 .animate-slide-in-left {

--- a/src/shared/styles/list-animations.css
+++ b/src/shared/styles/list-animations.css
@@ -1,0 +1,97 @@
+/* List Upload Animations */
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Animation Classes */
+.animate-fade-in {
+  animation: fade-in 0.5s ease-out;
+}
+
+.animate-slide-in-up {
+  animation: slide-in-up 0.6s ease-out;
+}
+
+.animate-slide-in-left {
+  animation: slide-in-left 0.6s ease-out;
+}
+
+.animate-scale-in {
+  animation: scale-in 0.4s ease-out;
+}
+
+/* Staggered Animation Delays */
+.animate-stagger-1 {
+  animation-delay: 0.1s;
+}
+.animate-stagger-2 {
+  animation-delay: 0.2s;
+}
+.animate-stagger-3 {
+  animation-delay: 0.3s;
+}
+.animate-stagger-4 {
+  animation-delay: 0.4s;
+}
+.animate-stagger-5 {
+  animation-delay: 0.5s;
+}
+
+/* Loading Spinner */
+.loading-spinner {
+  display: inline-block;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid var(--gray-light);
+  border-top: 2px solid var(--main-5);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -43,7 +43,7 @@ export function Modal({ isOpen, onClose, children, className }: ModalProps) {
     >
       <div
         className={cn(
-          'w-full max-w-md bg-[var(--white)] rounded-lg shadow-lg max-h-[90vh] overflow-y-auto',
+          'w-full max-w-sm bg-[var(--white)] rounded-lg shadow-lg max-h-[90vh] overflow-y-auto',
           className,
         )}
         onClick={(e) => e.stopPropagation()}

--- a/src/shared/ui/StoreLikeButton/StoreLikeButton.tsx
+++ b/src/shared/ui/StoreLikeButton/StoreLikeButton.tsx
@@ -1,0 +1,61 @@
+import Image from 'next/image';
+
+import { ICONS } from '@/shared/config/iconPath';
+
+interface StoreLikeButtonProps {
+  isLiked: boolean;
+  isLoading?: boolean;
+  onClick: (e: React.MouseEvent) => void;
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export function StoreLikeButton({
+  isLiked,
+  isLoading = false,
+  onClick,
+  className = '',
+  size = 'sm',
+}: StoreLikeButtonProps) {
+  const sizeClasses = {
+    sm: 'w-6 h-6',
+    md: 'w-8 h-8',
+    lg: 'w-10 h-10',
+  };
+
+  const imageSize = {
+    sm: 21,
+    md: 28,
+    lg: 35,
+  };
+
+  return (
+    <div
+      className={`rounded-full bg-white flex items-center justify-center shadow-lg ${sizeClasses[size]} ${className}`}
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={isLoading}
+        className="cursor-pointer p-0 border-none rounded-full flex items-center justify-center min-w-0 min-h-0"
+        style={{ width: imageSize[size], height: imageSize[size] }}
+      >
+        <Image
+          src={
+            isLiked
+              ? typeof ICONS.ETC.LIKE_ACTIVE === 'string'
+                ? ICONS.ETC.LIKE_ACTIVE
+                : ICONS.ETC.LIKE_ACTIVE.src
+              : typeof ICONS.ETC.LIKE_NONACTIVE === 'string'
+                ? ICONS.ETC.LIKE_NONACTIVE
+                : ICONS.ETC.LIKE_NONACTIVE.src
+          }
+          alt={isLiked ? '좋아요 활성' : '좋아요 비활성'}
+          width={imageSize[size]}
+          height={imageSize[size]}
+          className={isLoading ? 'opacity-50' : ''}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/shared/ui/StoreLikeButton/index.ts
+++ b/src/shared/ui/StoreLikeButton/index.ts
@@ -1,0 +1,1 @@
+export { StoreLikeButton } from './StoreLikeButton';


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #205 

### 🔎 작업 내용
### 1. 재입고 알림 관리 시스템
- 재입고 알림 삭제 API 연동 
- 삭제 확인 모달 UI 구현 및 토스트 알림 추가
- React Query useMutation을 활용한 삭제 로직 구현
- 인라인 모달과 알림 섹션을 별도 컴포넌트로 분리 (DeleteConfirmModal,  AlarmNoticeSection)

### 2. 가맹점 좋아요 시스템
- `StoreCard` 컴포넌트에 좋아요 기능 추가 및 `toggleStoreLike` API 연동
- `useStoreLikeToggle` 훅을 shared/hooks로 이동하고 `StoreLikeButton` 컴포넌트를 shared/ui로 분리
- `LikeStorePage`에 좋아요 취소 기능 추가 및 카드 제거 애니메이션 구현
- 목록에서 좋아요 토글 시 지도 마커 즉시 업데이트하는 낙관적 업데이트 시스템 구현

### 3. 지도 마커 시스템 개선
- 줌 레벨 3 이하에서 개별 가맹점 마커의 좋아요 상태 표시 (클러스터링 미적용)
- 로그인한 사용자의 좋아요 상태에 따른 마커 아이콘 동적 변경
- 전역 마커 업데이트 이벤트 시스템으로 여러 지도 인스턴스 동시 업데이트

### 4. 애니메이션 시스템
- 전역 CSS 애니메이션 파일 (list-animations.css) 생성
- `DragBottomSheet`에 리스트 애니메이션 적용하여 무한 스크롤 시 새 아이템에만 애니메이션 적용
- 재입고 알림 및 좋아요 페이지에 카드 삭제 시 slide-out-down 애니메이션 구현
- 삭제된 카드는 아래로 슬라이드하며 사라지고 남은 카드들이 위로 올라와 빈 공간 채움

### 📸 스크린샷
### 가맹점 목록 좋아요 생성/취소 API 연동 및 지도에 바로 반영

https://github.com/user-attachments/assets/d9aa635b-541c-4aae-9f9d-df9e51fa4c2e

### 마이페이지에서 가맹점 좋아요 취소 + 애니메이션 적용

https://github.com/user-attachments/assets/011951ea-62fa-4114-8a11-1077fefa7fb6

### 재입고 알림 취소 모달 확인 후 취소 API + 애니메이션 적용

https://github.com/user-attachments/assets/c679e07c-5de0-4069-aa67-5582202c2d31


### :loudspeaker: 전달사항
- 클러스터링 적용 전의 가맹점만 좋아요로 표시됩니다. 클러스터링 적용 후에는 동그란 원으로 표시될 것이므로 클러스터링 적용 후 변경 가능성 있음

### ✅ Check List

- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
