### PR TITLE
Feat: [BADA-311] 마이페이지_메인 data와 신고현황 API 연동 

### DIFF
--- a/src/features/mypage/report-status/api/apis.ts
+++ b/src/features/mypage/report-status/api/apis.ts
@@ -1,0 +1,14 @@
+import { END_POINTS } from '@/shared/api/endpoints';
+import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
+
+import type { ReportStatusResponse } from '../lib/types';
+
+
+
+export const getReportStatus = async (): Promise<ReportStatusResponse> => {
+  const response = await axiosInstance.get<ReportStatusResponse>(
+    END_POINTS.MYPAGE.REPORT_TOTAL_COUNT,
+  );
+
+  return response.data;
+};

--- a/src/features/mypage/report-status/api/apis.ts
+++ b/src/features/mypage/report-status/api/apis.ts
@@ -1,7 +1,7 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import type { ReportStatus } from '../lib/types';
+import type { ReportStatus } from '@/features/mypage/report-status/lib/types';
 
 export const getReportStatus = async (): Promise<ReportStatus> => {
   const content: ReportStatus = await axiosInstance.get(END_POINTS.MYPAGE.REPORT_TOTAL_COUNT);

--- a/src/features/mypage/report-status/api/apis.ts
+++ b/src/features/mypage/report-status/api/apis.ts
@@ -1,14 +1,9 @@
 import { END_POINTS } from '@/shared/api/endpoints';
 import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 
-import type { ReportStatusResponse } from '../lib/types';
+import type { ReportStatus } from '../lib/types';
 
-
-
-export const getReportStatus = async (): Promise<ReportStatusResponse> => {
-  const response = await axiosInstance.get<ReportStatusResponse>(
-    END_POINTS.MYPAGE.REPORT_TOTAL_COUNT,
-  );
-
-  return response.data;
+export const getReportStatus = async (): Promise<ReportStatus> => {
+  const content: ReportStatus = await axiosInstance.get(END_POINTS.MYPAGE.REPORT_TOTAL_COUNT);
+  return content;
 };

--- a/src/features/mypage/report-status/lib/types.ts
+++ b/src/features/mypage/report-status/lib/types.ts
@@ -1,0 +1,11 @@
+export interface ReportStatus {
+  questionCount: number;
+  answerCount: number;
+  completeCount: number;
+}
+
+export interface ReportStatusResponse {
+  code: number;
+  message: string | null;
+  content: ReportStatus;
+}

--- a/src/features/mypage/report-status/lib/types.ts
+++ b/src/features/mypage/report-status/lib/types.ts
@@ -3,9 +3,3 @@ export interface ReportStatus {
   answerCount: number;
   completeCount: number;
 }
-
-export interface ReportStatusResponse {
-  code: number;
-  message: string | null;
-  content: ReportStatus;
-}

--- a/src/features/mypage/report-status/model/queries.ts
+++ b/src/features/mypage/report-status/model/queries.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getReportStatus } from '../api/apis';
+import { getReportStatus } from '@/features/mypage/report-status/api/apis';
 
-import type { ReportStatus } from '../lib/types';
+import type { ReportStatus } from '@/features/mypage/report-status/lib/types';
 
 
 export const useReportStatusQuery = () =>

--- a/src/features/mypage/report-status/model/queries.ts
+++ b/src/features/mypage/report-status/model/queries.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getReportStatus } from '../api/apis';
+
+import type { ReportStatusResponse } from '../lib/types';
+
+export const useReportStatusQuery = () =>
+  useQuery<ReportStatusResponse>({
+    queryKey: ['report-status'],
+    queryFn: getReportStatus,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+  });

--- a/src/features/mypage/report-status/model/queries.ts
+++ b/src/features/mypage/report-status/model/queries.ts
@@ -2,14 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getReportStatus } from '../api/apis';
 
-import type { ReportStatusResponse } from '../lib/types';
+import type { ReportStatus } from '../lib/types';
+
 
 export const useReportStatusQuery = () =>
-  useQuery<ReportStatusResponse>({
+  useQuery<ReportStatus>({
     queryKey: ['report-status'],
     queryFn: getReportStatus,
-    staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 10,
-    refetchOnMount: true,
-    refetchOnWindowFocus: false,
   });
+

--- a/src/features/mypage/ui/DataUsageCardSection.tsx
+++ b/src/features/mypage/ui/DataUsageCardSection.tsx
@@ -5,12 +5,12 @@ import { useEffect, useState } from 'react';
 import { ArcElement, Chart, Tooltip } from 'chart.js';
 import { Doughnut } from 'react-chartjs-2';
 
-import { useUserDataUsageQuery } from '@/entities/data/model/queries';
+import { useUserDataAmount } from '@/widgets/data-usage/model/queries';
 
 Chart.register(ArcElement, Tooltip);
 
 export const DataUsageCardSection = () => {
-  const { data: usageData } = useUserDataUsageQuery(); // usageData: { used: number }
+  const { data } = useUserDataAmount();
   const [mainColor, setMainColor] = useState<string>('#0f225e');
 
   useEffect(() => {
@@ -18,8 +18,8 @@ export const DataUsageCardSection = () => {
     if (cssMain) setMainColor(cssMain);
   }, []);
 
-  const used = usageData?.dataAmount ?? 5;
-  const total = 10;
+  const used = data?.content.dataAmount ?? 0;
+  const total = data?.content.totalDataAmount ?? 1; // 0이면 나눗셈에서 NaN 될 수 있으니 기본값 1
 
   const chartData = {
     labels: ['사용량'],
@@ -42,7 +42,10 @@ export const DataUsageCardSection = () => {
       <div className="relative w-[160px] h-[160px]">
         <Doughnut data={chartData} options={options} />
         <div className="absolute inset-0 flex flex-col items-center justify-center font-semibold text-gray-900">
-          <span className="text-sm">{used}GB / {total}GB</span>
+          <span className="text-sm">
+            {used}GB
+            <br />/ {total}GB
+          </span>
         </div>
       </div>
     </div>

--- a/src/features/mypage/ui/ReportStatusSection.tsx
+++ b/src/features/mypage/ui/ReportStatusSection.tsx
@@ -2,8 +2,22 @@
 
 import Link from 'next/link';
 
-export const ReportStatusSection = () => (
-  <>
+import { useReportStatusQuery } from '@/features/mypage/report-status/model/queries';
+
+export const ReportStatusSection = () => {
+  const { data } = useReportStatusQuery();
+
+  const questionCount = data?.content.questionCount ?? 0;
+  const answerCount = data?.content.answerCount ?? 0;
+  const completeCount = data?.content.completeCount ?? 0;
+
+  const statusList = [
+    { count: questionCount, label: '신고 접수' },
+    { count: answerCount, label: '신고 검토' },
+    { count: completeCount, label: '신고 완료' },
+  ];
+
+  return (
     <section className="mt-8">
       <div className="flex justify-between items-end mb-2">
         <h2 className="font-body-semibold leading-[28px]">나의 신고 내역 조회</h2>
@@ -13,11 +27,7 @@ export const ReportStatusSection = () => (
       </div>
 
       <section className="grid grid-cols-3 gap-2 text-center">
-        {[
-          { count: 0, label: '신고 접수' },
-          { count: 1, label: '신고 검토' },
-          { count: 1, label: '신고 완료' },
-        ].map(({ count, label }) => (
+        {statusList.map(({ count, label }) => (
           <div
             key={label}
             className="bg-[var(--main-1)] rounded-xl p-4 shadow-sm flex flex-col items-center"
@@ -28,5 +38,5 @@ export const ReportStatusSection = () => (
         ))}
       </section>
     </section>
-  </>
-);
+  );
+};

--- a/src/features/mypage/ui/ReportStatusSection.tsx
+++ b/src/features/mypage/ui/ReportStatusSection.tsx
@@ -7,9 +7,10 @@ import { useReportStatusQuery } from '@/features/mypage/report-status/model/quer
 export const ReportStatusSection = () => {
   const { data } = useReportStatusQuery();
 
-  const questionCount = data?.content.questionCount ?? 0;
-  const answerCount = data?.content.answerCount ?? 0;
-  const completeCount = data?.content.completeCount ?? 0;
+  const questionCount = data?.questionCount ?? 0;
+  const answerCount = data?.answerCount ?? 0;
+  const completeCount = data?.completeCount ?? 0;
+
 
   const statusList = [
     { count: questionCount, label: '신고 접수' },

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -69,6 +69,7 @@ export const END_POINTS = {
     LIKE_TRADE_POST: '/api/v1/users/likes/posts',
     RESTOCK_ALARM: '/api/v1/users/restock',
     SOS_HISTORY: '/api/v1/users/sos',
+    REPORT_TOTAL_COUNT: '/api/v1/users/report/totalCount',
     REPORT_LIST: '/api/v1/users/reports',
     REPORT_INFO: (reportId: number) => `/api/v1/users/${reportId}/report/info`,
     NOTIFICATION: '/api/v1/users/notification',

--- a/src/widgets/data-usage/model/queries.ts
+++ b/src/widgets/data-usage/model/queries.ts
@@ -15,4 +15,17 @@ export const useDataUsageQuery = () => {
     refetchOnWindowFocus: false,
     refetchOnMount: true,
   });
-}; 
+};
+
+export const useUserDataAmount = () => {
+  return useQuery<DataUsageResponse>({
+    queryKey: ['data-usage'],
+    queryFn: getDataUsage,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    retry: 3,
+    retryDelay: 1000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+  });
+};

--- a/src/widgets/data-usage/model/queries.ts
+++ b/src/widgets/data-usage/model/queries.ts
@@ -4,19 +4,6 @@ import { getDataUsage } from '@/widgets/data-usage/api/apis';
 
 import type { DataUsageResponse } from '@/widgets/data-usage/types';
 
-export const useDataUsageQuery = () => {
-  return useQuery<DataUsageResponse>({
-    queryKey: ['data-usage'],
-    queryFn: getDataUsage,
-    staleTime: 1000 * 60 * 5, // 5분
-    gcTime: 1000 * 60 * 10, // 10분
-    retry: 3,
-    retryDelay: 1000,
-    refetchOnWindowFocus: false,
-    refetchOnMount: true,
-  });
-};
-
 export const useUserDataAmount = () => {
   return useQuery<DataUsageResponse>({
     queryKey: ['data-usage'],


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #206 

### 🔎 작업 내용

- [x] 마이페이지 신고 현황 API 연동
- /api/v1/users/report/totalCount 호출하여 신고 접수/검토/완료 수치 표시
- ReportStatusSection 컴포넌트에 데이터 바인딩 적용
- axiosInstance 구조에 맞춰 content만 반환하도록 API/쿼리 수정

- [x] 데이터 사용량 조회 API 연동 및 도넛 차트 표시
- /api/v1/users/data API 연동 후 dataAmount, totalDataAmount 추출
- DataUsageCardSection 내 실제 사용량 기반 차트 시각화 구현
- 불필요한 타입 중복 제거 및 쿼리 캐싱 설정 적용

### 📸 스크린샷
Uploading 마이페이지_메인 데이터 및 메인 신고 현황 API 연동.mp4…

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
