### PR TITLE
Fix: [BADA-325] userInfo 완전한 데이터 로딩 후 랜더링 되도록 수정

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -18,7 +18,11 @@ import MyProfileCard from '@/widgets/user/ui/MyProfileCard';
 
 export default function MyPage() {
   const { data: coinData } = useUserCoinQuery();
-  const { data: userInfo } = useUserInfoQuery();
+  const { data: userInfo, isLoading: isUserInfoLoading } = useUserInfoQuery();
+
+  // 모든 사용자 정보가 로딩된 후에만 프로필 카드 렌더링
+  const isProfileReady =
+    userInfo && userInfo.nickName && userInfo.profileImage && userInfo.days !== undefined;
 
   return (
     <div className="relative w-full min-h-screen bg-[var(--main-2)]">
@@ -29,11 +33,20 @@ export default function MyPage() {
       <main className="pt-[70px] pb-[70px] w-full max-w-[428px] mx-auto">
         <div className="w-full bg-[var(--main-1)] pb-16 relative">
           <div className="pt-4 flex justify-center">
-            <MyProfileCard
-              name={userInfo?.nickName ?? '사용자'}
-              days={userInfo?.days ?? 0}
-              avatarSrc={userInfo?.profileImage ?? ICONS.ETC.SHELL.src.toString()}
-            />
+            {isProfileReady ? (
+              <MyProfileCard
+                name={userInfo.nickName}
+                days={userInfo.days}
+                avatarSrc={userInfo.profileImage}
+              />
+            ) : (
+              <MyProfileCard
+                name="로딩 중..."
+                days={0}
+                avatarSrc={ICONS.ETC.SHELL.src.toString()}
+                isLoading={isUserInfoLoading}
+              />
+            )}
           </div>
           <div className="relative px-4 pt-4 mb-4">
             <DataUsageCardSection />
@@ -71,7 +84,7 @@ export default function MyPage() {
       <div className="bg-[var(--white)] fixed bottom-0 left-0 right-0 z-50 max-w-[428px] mx-auto">
         <BottomNav />
       </div>
-      
+
       {/* SOS Drawer 추가 */}
       <SosDrawer />
     </div>

--- a/src/features/mypage/purchase-history/page/PurchaseHistoryPage.tsx
+++ b/src/features/mypage/purchase-history/page/PurchaseHistoryPage.tsx
@@ -29,7 +29,7 @@ export default function PurchaseHistoryPage() {
   } = useUserStats();
 
   const { data: soldPostsCount } = useUserSoldPostsCountQuery(profile?.userId);
-  const { data: userInfo } = useUserInfoQuery();
+  const { data: userInfo, isLoading: isUserInfoLoading } = useUserInfoQuery();
 
   useEffect(() => {
     const handleFocus = () => {
@@ -64,11 +64,20 @@ export default function PurchaseHistoryPage() {
     >
       <div className="w-full max-w-[428px]">
         <div className="flex flex-col items-center mt-4">
-          <MyProfileCard
-            name={userInfo?.nickName ?? '사용자'}
-            days={userInfo?.days ?? 0}
-            avatarSrc={userInfo?.profileImage ?? ICONS.ETC.SHELL.src.toString()}
-          />
+          {userInfo && userInfo.nickName && userInfo.profileImage && userInfo.days !== undefined ? (
+            <MyProfileCard
+              name={userInfo.nickName}
+              days={userInfo.days}
+              avatarSrc={userInfo.profileImage}
+            />
+          ) : (
+            <MyProfileCard
+              name="로딩 중..."
+              days={0}
+              avatarSrc={ICONS.ETC.SHELL.src.toString()}
+              isLoading={isUserInfoLoading}
+            />
+          )}
 
           <div className="flex justify-between items-center w-full bg-[var(--main-1)] rounded-xl px-4 py-3 mt-6 mb-6">
             <div className="flex flex-col items-center flex-1">

--- a/src/features/mypage/sales-history/page/SalesHistoryPage.tsx
+++ b/src/features/mypage/sales-history/page/SalesHistoryPage.tsx
@@ -43,7 +43,7 @@ export default function SalesHistoryPage() {
   } = useUserStats();
 
   const { data: soldPostsCount } = useUserSoldPostsCountQuery(profile?.userId);
-  const { data: userInfo } = useUserInfoQuery();
+  const { data: userInfo, isLoading: isUserInfoLoading } = useUserInfoQuery();
 
   const postCategory = tab === '전체' ? undefined : tab === '데이터' ? 'DATA' : 'GIFTICON';
 
@@ -110,11 +110,20 @@ export default function SalesHistoryPage() {
     >
       <div className="w-full max-w-[428px]">
         <div className="flex flex-col items-center mt-4">
-          <MyProfileCard
-            name={userInfo?.nickName ?? '사용자'}
-            days={userInfo?.days ?? 0}
-            avatarSrc={userInfo?.profileImage ?? ICONS.ETC.SHELL.src.toString()}
-          />
+          {userInfo && userInfo.nickName && userInfo.profileImage && userInfo.days !== undefined ? (
+            <MyProfileCard
+              name={userInfo.nickName}
+              days={userInfo.days}
+              avatarSrc={userInfo.profileImage}
+            />
+          ) : (
+            <MyProfileCard
+              name="로딩 중..."
+              days={0}
+              avatarSrc={ICONS.ETC.SHELL.src.toString()}
+              isLoading={isUserInfoLoading}
+            />
+          )}
 
           <div className="flex justify-between items-center w-full bg-[var(--main-1)] rounded-xl px-4 py-3 mt-4 mb-6">
             <div className="flex flex-col items-center flex-1">

--- a/src/shared/ui/UserAvatar/UserAvatar.tsx
+++ b/src/shared/ui/UserAvatar/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Image from 'next/image';
 
@@ -9,6 +9,7 @@ interface UserAvatarProps {
   alt?: string;
   size?: 'lg' | 'md'; // lg: 70x70, md: 58x58
   className?: string;
+  isLoading?: boolean;
 }
 
 /**
@@ -17,6 +18,7 @@ interface UserAvatarProps {
  * @param alt - 대체 텍스트
  * @param size - 'lg'(70x70) | 'md'(58x58)
  * @param className - 추가 커스텀 클래스
+ * @param isLoading - 로딩 상태 여부
  */
 const sizeMap = {
   lg: 'w-[70px] h-[70px]',
@@ -25,8 +27,32 @@ const sizeMap = {
 
 const DEFAULT_AVATAR = ICONS.ETC.SHELL;
 
-const UserAvatar = ({ src, alt = '유저 아바타', size = 'md', className = '' }: UserAvatarProps) => {
-  const [imgSrc, setImgSrc] = useState(src || DEFAULT_AVATAR);
+const UserAvatar = ({
+  src,
+  alt = '유저 아바타',
+  size = 'md',
+  className = '',
+  isLoading = false,
+}: UserAvatarProps) => {
+  const [imgSrc, setImgSrc] = useState<typeof DEFAULT_AVATAR | string>(DEFAULT_AVATAR);
+
+  // src가 변경될 때마다 imgSrc 업데이트
+  useEffect(() => {
+    if (src) {
+      setImgSrc(src);
+    } else {
+      setImgSrc(DEFAULT_AVATAR);
+    }
+  }, [src]);
+
+  // 로딩 중일 때는 스켈레톤 효과 적용
+  if (isLoading) {
+    return (
+      <div
+        className={`rounded-full border border-[var(--gray)] bg-[var(--gray-light)] ${sizeMap[size]} ${className} animate-pulse`}
+      />
+    );
+  }
 
   return (
     <Image

--- a/src/widgets/trade/post-detail/ui/TradeDetailSellerSection.tsx
+++ b/src/widgets/trade/post-detail/ui/TradeDetailSellerSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
 import { useTradePostLikeHooks } from '@/entities/trade-post/model/useTradePostLikeHooks';
 import { useUserTradePostsQuery } from '@/widgets/trade/post-detail/model/queries';
 import SellerPostCard from '@/widgets/trade/ui/SellerPostCard';
@@ -20,6 +22,7 @@ export const TradeDetailSellerSection = ({
   isFollowing,
   onFollowChange,
 }: TradeDetailSellerSectionProps) => {
+  const router = useRouter();
   const { data, isLoading, error } = useUserTradePostsQuery(sellerId);
   const { toggleLike, getCachedLikeState } = useTradePostLikeHooks();
 
@@ -32,6 +35,13 @@ export const TradeDetailSellerSection = ({
       ...post,
       isLiked: cachedLikeState,
     };
+  };
+
+  // 상품 상세페이지로 이동하는 함수
+  const handleCardClick = (post: AllPost) => {
+    const detailPath =
+      post.postCategory === 'DATA' ? `/trade/data/${post.id}` : `/trade/gifticon/${post.id}`;
+    router.push(detailPath);
   };
 
   return (
@@ -71,6 +81,7 @@ export const TradeDetailSellerSection = ({
                   likeCount={item.likesCount}
                   isLiked={updatedPost.isLiked}
                   onLikeChange={() => toggleLike(updatedPost)}
+                  onClick={() => handleCardClick(item)}
                 />
               );
             })}

--- a/src/widgets/trade/ui/SellerPostCard.tsx
+++ b/src/widgets/trade/ui/SellerPostCard.tsx
@@ -23,6 +23,7 @@ interface SellerPostCardProps {
   dday?: number | string;
   isLiked?: boolean;
   onLikeChange?: (liked: boolean) => void;
+  onClick?: () => void;
   className?: string;
 }
 
@@ -35,6 +36,7 @@ interface SellerPostCardProps {
  * @param likeCount - 좋아요 수
  * @param hasDday - 디데이 뱃지 표시 여부
  * @param dday - 디데이 값
+ * @param onClick - 카드 클릭 핸들러
  * @param className - 추가 커스텀 클래스
  */
 const SellerPostCard = ({
@@ -47,6 +49,7 @@ const SellerPostCard = ({
   dday,
   isLiked = false,
   onLikeChange,
+  onClick,
   className = '',
 }: SellerPostCardProps) => {
   const getSafeImageUrl = (): string => {
@@ -64,9 +67,20 @@ const SellerPostCard = ({
     return DEFAULT_IMAGE;
   };
 
+  const handleCardClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 이벤트 버블링 방지
+    onClick?.();
+  };
+
+  const handleLikeClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 좋아요 버튼 클릭 시 카드 클릭 이벤트 방지
+    onLikeChange?.(!isLiked);
+  };
+
   return (
     <div
-      className={`w-[120px] h-[189px] rounded-[20px] bg-[var(--gray-light)] flex flex-col items-center p-1.5 flex-shrink-0 ${className}`}
+      className={`w-[120px] h-[189px] rounded-[20px] bg-[var(--gray-light)] flex flex-col items-center p-1.5 flex-shrink-0 cursor-pointer ${className}`}
+      onClick={handleCardClick}
     >
       <div className="relative w-[106px] h-[102px] rounded-[15px] overflow-hidden bg-[var(--white)] flex items-center justify-center">
         {hasDday && (
@@ -75,7 +89,7 @@ const SellerPostCard = ({
           </div>
         )}
         <div className="absolute bottom-1 right-1 z-10">
-          <PostLikeButton active={isLiked} onClick={() => onLikeChange?.(!isLiked)} />
+          <PostLikeButton active={isLiked} onClick={handleLikeClick} />
         </div>
         <Image
           src={getSafeImageUrl()}

--- a/src/widgets/user/ui/MyProfileCard.tsx
+++ b/src/widgets/user/ui/MyProfileCard.tsx
@@ -3,8 +3,9 @@ import UserAvatar from '@/shared/ui/UserAvatar';
 interface MyProfileCardProps {
   name: string;
   days: number;
-  avatarSrc?: string;
+  avatarSrc: string;
   className?: string;
+  isLoading?: boolean;
 }
 
 /**
@@ -13,19 +14,36 @@ interface MyProfileCardProps {
  * @param days - BADATA와 함께한 일수
  * @param avatarSrc - 아바타 이미지 URL
  * @param className - 추가 커스텀 클래스
+ * @param isLoading - 로딩 상태 여부
  */
-const MyProfileCard = ({ name, days, avatarSrc, className = '' }: MyProfileCardProps) => {
+const MyProfileCard = ({
+  name,
+  days,
+  avatarSrc,
+  className = '',
+  isLoading = false,
+}: MyProfileCardProps) => {
   return (
     <div className={`flex items-center w-[380px] h-[70px] ${className}`}>
-      <UserAvatar src={avatarSrc} size="lg" className="flex-shrink-0" />
+      <UserAvatar src={avatarSrc} size="lg" className="flex-shrink-0" isLoading={isLoading} />
       <div className="flex flex-col justify-center ml-8 flex-1">
-        <span className="text-[var(--black)] font-body-semibold leading-none text-right">
-          {name}
-        </span>
-        <span className="text-[var(--black)] font-small-regular leading-[20px] text-right mt-1.5">
-          BADATA와 함께 한지{' '}
-          <span className="font-small-semibold text-[var(--main-5)]">{days}</span>일째
-        </span>
+        {isLoading ? (
+          <div className="flex flex-col items-end">
+            <div className="h-5 w-20 bg-gray-200 rounded animate-pulse mb-2" />
+            <div className="h-3 w-20 bg-gray-200 rounded animate-pulse" />
+          </div>
+        ) : (
+          <>
+            <span className="text-[var(--black)] font-body-semibold leading-none text-right">
+              {name}
+            </span>
+            <span className="text-[var(--black)] font-small-regular leading-[20px] text-right mt-1.5">
+              BADATA와 함께 한지{' '}
+              <span className="font-small-semibold text-[var(--main-5)]">{days}</span>
+              일째
+            </span>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #221

### 🔎 작업 내용

프로필 이미지 로딩 문제 해결 과정
: 새로고침 시 이미지는 프로필 이미지가 아닌 기본 이미지로 표시되지만, 이름과 일수는 정상적으로 표시됨

- [x] UserAvatar: useState -> useEffect로 변경, loading 상태 추가 후 스켈레톤 ui 추가
- [x] MyProfileCard: 완전한 데이터 로딩 후에만 랜더링, 로딩 중일 때 스켈레톤 ui 추가

### 📸 스크린샷

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
