### PR TITLE
Feat: [BADA-333] 게시물 전체 조회, 마감임박 게시물 조회 API 응답 프로퍼티명 변경

### DIFF
--- a/src/entities/trade-post/api/apis.ts
+++ b/src/entities/trade-post/api/apis.ts
@@ -15,10 +15,8 @@ import type {
 
 // 게시물 목록 조회
 export const getTradePosts = async (): Promise<DeadlinePost[]> => {
-  const content: { postsResponse: DeadlinePost[] } = await axiosInstance.get(
-    END_POINTS.TRADES.LIST,
-  );
-  return content.postsResponse ?? [];
+  const content: { item: DeadlinePost[] } = await axiosInstance.get(END_POINTS.TRADES.LIST);
+  return content.item ?? [];
 };
 
 // 게시물 삭제

--- a/src/features/trade/api/apis.ts
+++ b/src/features/trade/api/apis.ts
@@ -4,10 +4,8 @@ import { axiosInstance } from '@/shared/lib/axios/axiosInstance';
 import type { DeadlinePost as PostItem } from '@/entities/trade-post/lib/types';
 
 export const getTradeDeadlinePosts = async (): Promise<PostItem[]> => {
-  const content: { postsResponse: PostItem[] } = await axiosInstance.get(
-    END_POINTS.TRADES.DEADLINE,
-  );
-  return content.postsResponse ?? [];
+  const content: { item: PostItem[] } = await axiosInstance.get(END_POINTS.TRADES.DEADLINE);
+  return content.item ?? [];
 };
 
 export const getTradeTrendingPosts = async (): Promise<PostItem[]> => {


### PR DESCRIPTION
### #️⃣연관된 이슈


> close: #229

### 🔎 작업 내용

- [x] 거래 게시물 전체 조회, 마감임박 게시물 조회 응답 프로퍼티 수정


### 📸 스크린샷

### :loudspeaker: 전달사항
- 변경 후 응답 잘 받아오는 것 확인했습니다!

### ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
