### PR TITLE
Refactor: 무한스크롤 대신 가상스크롤 적용하여 최적화

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -42,7 +42,9 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withPWA({
-  ...nextConfig,
+const withPWAConfigured = withPWA({
   dest: 'public',
+  disable: process.env.NODE_ENV === 'development', 
 });
+
+export default withPWAConfigured(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-dom": "^19.0.0",
         "react-intersection-observer": "^9.16.0",
         "react-kakao-maps-sdk": "^1.2.0",
+        "react-virtuoso": "^4.14.0",
         "sonner": "^2.0.6",
         "swiper": "^11.2.10",
         "tailwind-merge": "^3.3.1",
@@ -12094,6 +12095,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.14.0.tgz",
+      "integrity": "sha512-fR+eiCvirSNIRvvCD7ueJPRsacGQvUbjkwgWzBZXVq+yWypoH7mRUvWJzGHIdoRaCZCT+6mMMMwIG2S1BW3uwA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/recast": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^19.0.0",
     "react-intersection-observer": "^9.16.0",
     "react-kakao-maps-sdk": "^1.2.0",
+    "react-virtuoso": "^4.14.0",
     "sonner": "^2.0.6",
     "swiper": "^11.2.10",
     "tailwind-merge": "^3.3.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,6 +62,15 @@ export default function RootLayout({
           href="https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js"
           as="script"
         />
+
+        {/* 이미지 CDN 미리 연결 */}
+        <link rel="preconnect" href="https://img1.kakaocdn.net" crossOrigin="" />
+        <link rel="preconnect" href="https://k.kakaocdn.net" crossOrigin="" />
+        <link
+          rel="preconnect"
+          href="https://badatabucket.s3.ap-northeast-2.amazonaws.com"
+          crossOrigin=""
+        />
       </head>
       <body className="antialiased">
         {/* 외부 스크립트 - 성능 최적화 */}

--- a/src/features/rental/map/hooks/useRafThrottleHooks.ts
+++ b/src/features/rental/map/hooks/useRafThrottleHooks.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * requestAnimationFrame으로 호출을 프레임당 1회로 묶는다.
+ */
+export function useRafThrottle<A extends readonly unknown[]>(fn: (...args: A) => void) {
+  const rafIdRef = useRef<number | null>(null);
+  const lastArgsRef = useRef<A | null>(null);
+
+  const throttled = useCallback(
+    (...args: A) => {
+      lastArgsRef.current = args;
+      if (rafIdRef.current === null) {
+        rafIdRef.current = requestAnimationFrame(() => {
+          rafIdRef.current = null;
+          const argsToUse = lastArgsRef.current;
+          if (argsToUse) fn(...argsToUse);
+        });
+      }
+    },
+    [fn],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, []);
+
+  return throttled;
+}

--- a/src/features/rental/map/hooks/useStableStoreCardPropsHooks.ts
+++ b/src/features/rental/map/hooks/useStableStoreCardPropsHooks.ts
@@ -1,0 +1,72 @@
+'use client';
+import { useMemo, useRef } from 'react';
+
+import type { StoreCardProps, StoreListItem } from '@/features/rental/map/lib/types';
+
+function shallowEqualCard(a: StoreCardProps, b: StoreCardProps) {
+  return (
+    a.id === b.id &&
+    a.deviceCount === b.deviceCount &&
+    a.isLiked === b.isLiked &&
+    a.store.id === b.store.id &&
+    a.store.name === b.store.name &&
+    a.store.leftDeviceCount === b.store.leftDeviceCount &&
+    a.store.latitude === b.store.latitude &&
+    a.store.longititude === b.store.longititude &&
+    a.storeDetail.imageUrl === b.storeDetail.imageUrl &&
+    a.storeDetail.detailAddress === b.storeDetail.detailAddress &&
+    a.storeDetail.isOpening === b.storeDetail.isOpening &&
+    a.storeDetail.startTime === b.storeDetail.startTime &&
+    a.storeDetail.endTime === b.storeDetail.endTime &&
+    a.storeDetail.distanceFromMe === b.storeDetail.distanceFromMe
+  );
+}
+
+/** StoreListItem[] → 안정화된 StoreCardProps[] (동일 값이면 이전 객체 참조를 재사용) */
+export function useStableStoreCardProps(stores: StoreListItem[]) {
+  const cacheRef = useRef<Map<number, StoreCardProps>>(new Map());
+
+  return useMemo<StoreCardProps[]>(() => {
+    const out: StoreCardProps[] = [];
+    const cache = cacheRef.current;
+
+    for (const s of stores) {
+      const prev = cache.get(s.id);
+
+      const nextCandidate: StoreCardProps = {
+        id: s.id,
+        store: {
+          id: s.id,
+          name: s.name,
+          leftDeviceCount: s.leftDeviceCount,
+          liked: s.liked,
+          latitude: s.latitude,
+          longititude: s.longititude,
+        },
+        storeDetail: {
+          storeId: s.id,
+          imageUrl: s.storeImageUrl,
+          detailAddress: s.detailAddress,
+          reviewRating: 0,
+          isOpening: s.opening,
+          startTime: s.openTime,
+          endTime: s.closeTime,
+          distanceFromMe: s.distanceFromMe,
+          name: s.name,
+        },
+        deviceCount: s.leftDeviceCount,
+        isLiked: s.liked,
+        // onLikeToggle/onLikeClick 등 액션 프롭이 타입에 있더라도 대부분 선택(Optional)이므로 생략
+      };
+
+      if (prev && shallowEqualCard(prev, nextCandidate)) {
+        out.push(prev); // 값 동일 → 이전 참조 재사용
+      } else {
+        cache.set(s.id, nextCandidate);
+        out.push(nextCandidate);
+      }
+    }
+
+    return out;
+  }, [stores]);
+}

--- a/src/features/rental/map/page/RentalPage.tsx
+++ b/src/features/rental/map/page/RentalPage.tsx
@@ -5,10 +5,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useDrawerState } from '@/features/rental/map/hooks/useDrawerStaterHooks';
 import { useFilterState } from '@/features/rental/map/hooks/useFilterStaterHooks';
 import { useSelectedStore } from '@/features/rental/map/hooks/useSelectedStoreHooks';
-import {
-  convertToStoreCardProps,
-  useStoreListWithInfiniteScroll,
-} from '@/features/rental/map/hooks/useStoreListHooks';
+import { useStoreListWithInfiniteScroll } from '@/features/rental/map/hooks/useStoreListHooks';
 import { useUrlParams } from '@/features/rental/map/hooks/useUrlParamsrHooks';
 import { useUserLocation } from '@/features/rental/map/hooks/useUserLocationrHooks';
 import { useZoom } from '@/features/rental/map/hooks/useZoomHooks';
@@ -25,6 +22,8 @@ import { FilterDrawer } from '@/shared/ui/FilterDrawer';
 import { FilterIcon } from '@/shared/ui/FilterIcon/FilterIcon';
 import { Header_Detail } from '@/shared/ui/Header_Detail/Header_Detail';
 import { ZoomButton } from '@/widgets/zoom-button';
+
+import { useStableStoreCardProps } from '../hooks/useStableStoreCardPropsHooks';
 
 import type { StoreDetail, StoreDevice } from '@/features/rental/map/lib/types';
 
@@ -483,7 +482,13 @@ export default function RentalPage() {
   }, [isDrawerOpen, stores.length, refetch]);
 
   // 메모이제이션된 데이터
-  const storeList = useMemo(() => convertToStoreCardProps(stores), [stores]);
+  const storeList = useStableStoreCardProps(stores);
+
+  const handleLoadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const filteredDevicesList = useMemo(
     () => filterDevices(selectedStore.selectedDevices, filterState),
@@ -593,7 +598,7 @@ export default function RentalPage() {
             error={error}
             open={isDrawerOpen}
             onClose={() => setIsDrawerOpen(false)}
-            onLoadMore={fetchNextPage}
+            onLoadMore={handleLoadMore}
             onSortClick={handleSortClick}
             currentSort={currentSort}
           />

--- a/src/features/rental/map/ui/DragBottomSheet.tsx
+++ b/src/features/rental/map/ui/DragBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { motion, useAnimation } from 'framer-motion';
 import { ArrowUpDown } from 'lucide-react';
@@ -76,6 +76,10 @@ export const DragBottomSheet = ({
       }
     }
   }, [open, windowHeight, calculatedValues, controls]);
+
+  const handleEndReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
+  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
 
   const handleDragEnd = (_: unknown, info: { point: { y: number } }) => {
     const { y } = info.point;
@@ -173,9 +177,7 @@ export const DragBottomSheet = ({
                 </div>
               </div>
             )}
-            endReached={() => {
-              if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
-            }}
+            endReached={handleEndReached}
             components={{
               Footer: () =>
                 isFetchingNextPage ? (

--- a/src/features/rental/map/ui/DragBottomSheet.tsx
+++ b/src/features/rental/map/ui/DragBottomSheet.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-import { motion, useAnimation } from 'framer-motion';
+import { motion, useAnimation, useMotionValue, useTransform, type PanInfo } from 'framer-motion';
 import { ArrowUpDown } from 'lucide-react';
 import { Virtuoso } from 'react-virtuoso';
 
+import { useRafThrottle } from '@/features/rental/map/hooks/useRafThrottleHooks';
 import { StoreCard } from '@/features/rental/map/ui/StoreCard';
 
 import type { DragBottomSheetProps } from '@/features/rental/map/lib/types';
@@ -36,10 +37,14 @@ export const DragBottomSheet = ({
   currentSort = 'distance,asc',
 }: ExtendedDragBottomSheetProps) => {
   const [windowHeight, setWindowHeight] = useState(0);
-  const [currentY, setCurrentY] = useState(0);
   const lastOpenRef = useRef(false);
   const controls = useAnimation();
 
+  // 1) 위치를 state가 아니라 motionValue로 (드래그 중 React 렌더 0회)
+  const y = useMotionValue(0);
+  const heightMV = useTransform(y, (v) => `calc(${windowHeight}px - ${v}px)`);
+
+  // 포지션 프리셋
   const calculatedValues = useMemo(() => {
     const expandedY = windowHeight > 0 ? 60 : 0;
     const middleY = windowHeight > 0 ? windowHeight * 0.3 : 0;
@@ -47,62 +52,74 @@ export const DragBottomSheet = ({
     return { expandedY, middleY, collapsedY };
   }, [windowHeight]);
 
+  // 최초 높이 측정 & 초기 위치(접힘)
   useLayoutEffect(() => {
     if (typeof window !== 'undefined') {
-      const height = window.innerHeight;
-      setWindowHeight(height);
-      setCurrentY(height * 0.8);
+      const h = window.innerHeight;
+      setWindowHeight(h);
+      y.set(h * 0.8);
     }
-  }, []);
+  }, [y]);
 
+  // 열림/닫힘에 따라 위치 애니메이션
   useEffect(() => {
     if (windowHeight === 0) return;
 
     if (open !== lastOpenRef.current) {
-      lastOpenRef.current = open || false;
+      lastOpenRef.current = !!open;
 
       if (open) {
         controls.start({
           y: calculatedValues.expandedY,
           transition: { type: 'spring', damping: 25, stiffness: 200 },
         });
-        setCurrentY(calculatedValues.expandedY);
+        y.set(calculatedValues.expandedY);
       } else {
         controls.start({
           y: calculatedValues.collapsedY,
           transition: { type: 'spring', damping: 25, stiffness: 200 },
         });
-        setCurrentY(calculatedValues.collapsedY);
+        y.set(calculatedValues.collapsedY);
       }
     }
-  }, [open, windowHeight, calculatedValues, controls]);
+  }, [open, windowHeight, calculatedValues, controls, y]);
 
+  // Virtuoso의 endReached → 패칭 트리거
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
   }, [hasNextPage, isFetchingNextPage, onLoadMore]);
 
+  // 2) 드래그 중 위치 업데이트: rAF로 프레임당 1회 반영
+  const onDragRaf = useRafThrottle<[MouseEvent | TouchEvent | PointerEvent, PanInfo]>(
+    (_evt, info) => {
+      const next = Math.max(0, Math.min(info.point.y, windowHeight));
+      y.set(next);
+    },
+  );
+
   const handleDragEnd = (_: unknown, info: { point: { y: number } }) => {
-    const { y } = info.point;
+    const { y: py } = info.point;
     const threshold = 50;
-    if (y < calculatedValues.middleY - threshold) {
+
+    if (py < calculatedValues.middleY - threshold) {
       controls.start({
         y: calculatedValues.expandedY,
         transition: { type: 'spring', damping: 25, stiffness: 200 },
       });
-      setCurrentY(calculatedValues.expandedY);
-    } else if (y > calculatedValues.middleY + threshold) {
+      y.set(calculatedValues.expandedY);
+    } else if (py > calculatedValues.middleY + threshold) {
       controls.start({
         y: calculatedValues.collapsedY,
         transition: { type: 'spring', damping: 25, stiffness: 200 },
       });
-      setCurrentY(calculatedValues.collapsedY);
+      y.set(calculatedValues.collapsedY);
       onClose?.();
     } else {
       controls.start({
         y: calculatedValues.middleY,
         transition: { type: 'spring', damping: 25, stiffness: 200 },
       });
-      setCurrentY(calculatedValues.middleY);
+      y.set(calculatedValues.middleY);
     }
   };
 
@@ -128,12 +145,14 @@ export const DragBottomSheet = ({
       drag="y"
       dragConstraints={{ top: 0, bottom: windowHeight }}
       dragElastic={0.1}
+      onDrag={onDragRaf} // ← rAF로 배치
       onDragEnd={handleDragEnd}
       initial={false}
       animate={controls}
       style={{
-        y: currentY,
-        height: `calc(${windowHeight}px - ${currentY}px)`,
+        y, // transform: translateY(...) (GPU 경로)
+        height: heightMV, // 파생 height만 업데이트 (계산은 내부에서)
+        willChange: 'transform,height',
         minHeight: '200px',
         zIndex: 40,
       }}
@@ -156,7 +175,7 @@ export const DragBottomSheet = ({
       <div className="flex-1 pb-36 overflow-hidden">
         {isLoading ? (
           <div className="flex flex-col items-center justify-center gap-3 px-4 pt-8 pb-6 min-h-[200px]">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
             <div className="text-center text-[var(--gray-dark)]">스토어 목록을 불러오는 중...</div>
           </div>
         ) : isError ? (
@@ -182,7 +201,7 @@ export const DragBottomSheet = ({
               Footer: () =>
                 isFetchingNextPage ? (
                   <div className="text-center text-[var(--gray-dark)] py-4">
-                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500 mx-auto mb-2"></div>
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500 mx-auto mb-2" />
                     더 많은 스토어를 불러오는 중...
                   </div>
                 ) : hasNextPage ? (

--- a/src/features/rental/map/ui/DragBottomSheet.tsx
+++ b/src/features/rental/map/ui/DragBottomSheet.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { motion, useAnimation } from 'framer-motion';
 import { ArrowUpDown } from 'lucide-react';
+import { Virtuoso } from 'react-virtuoso';
 
 import { StoreCard } from '@/features/rental/map/ui/StoreCard';
 
@@ -15,9 +16,9 @@ interface ExtendedDragBottomSheetProps extends DragBottomSheetProps {
   hasNextPage?: boolean;
   isError?: boolean;
   error?: Error | null;
-  onLoadMore?: () => void; // 무한 스크롤을 위한 콜백 추가
-  onSortClick?: () => void; // 정렬 기준 클릭 핸들러
-  currentSort?: string; // 현재 정렬 기준
+  onLoadMore?: () => void;
+  onSortClick?: () => void;
+  currentSort?: string;
 }
 
 export const DragBottomSheet = ({
@@ -36,115 +37,63 @@ export const DragBottomSheet = ({
 }: ExtendedDragBottomSheetProps) => {
   const [windowHeight, setWindowHeight] = useState(0);
   const [currentY, setCurrentY] = useState(0);
-  const lastOpenRef = useRef(false); // useRef로 이전 상태 추적
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [animatedItems, setAnimatedItems] = useState<Set<string>>(new Set());
-  const [lastStoreCount, setLastStoreCount] = useState(0);
-  const renderCountRef = useRef(0);
-
-  // 메모이제이션된 계산값들
-  const calculatedValues = useMemo(() => {
-    const expandedY = windowHeight > 0 ? 60 : 0; // header 높이
-    const middleY = windowHeight > 0 ? windowHeight * 0.3 : 0; // 중간 높이를 30%로 조정
-    const collapsedY = windowHeight > 0 ? windowHeight * 0.8 : 0; // 접힌 높이 (80% 아래)
-
-    return { expandedY, middleY, collapsedY };
-  }, [windowHeight]);
-
-  // 무한 스크롤 핸들러 (디바운싱 적용)
-  const handleScroll = useCallback(() => {
-    if (!scrollContainerRef.current || !onLoadMore || isFetchingNextPage || !hasNextPage) return;
-
-    const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current;
-    const isNearBottom = scrollTop + clientHeight >= scrollHeight - 100; // 하단 100px 전에 로드
-
-    if (isNearBottom) {
-      onLoadMore();
-    }
-  }, [onLoadMore, isFetchingNextPage, hasNextPage]);
-
-  // 새로 로드된 아이템들을 추적하여 애니메이션 적용 (메모이제이션)
-  useEffect(() => {
-    if (storeList && storeList.length > lastStoreCount) {
-      const newItems = storeList.slice(lastStoreCount);
-      const newAnimatedItems = new Set(animatedItems);
-
-      // 새로 로드된 아이템들을 애니메이션 대상으로 추가
-      newItems.forEach((store, index) => {
-        const itemKey = `${store.id || `item-${lastStoreCount + index}`}`;
-        newAnimatedItems.add(itemKey);
-      });
-
-      setAnimatedItems(newAnimatedItems);
-      setLastStoreCount(storeList.length);
-    }
-  }, [storeList, lastStoreCount, animatedItems]);
-
+  const lastOpenRef = useRef(false);
   const controls = useAnimation();
 
-  // 렌더링 횟수 제한 (개발 환경에서만)
-  renderCountRef.current += 1;
+  const calculatedValues = useMemo(() => {
+    const expandedY = windowHeight > 0 ? 60 : 0;
+    const middleY = windowHeight > 0 ? windowHeight * 0.3 : 0;
+    const collapsedY = windowHeight > 0 ? windowHeight * 0.8 : 0;
+    return { expandedY, middleY, collapsedY };
+  }, [windowHeight]);
 
   useLayoutEffect(() => {
     if (typeof window !== 'undefined') {
       const height = window.innerHeight;
       setWindowHeight(height);
-      // 초기값을 collapsed 상태로 설정 (닫힌 상태)
       setCurrentY(height * 0.8);
     }
   }, []);
 
   useEffect(() => {
-    if (windowHeight === 0) {
-      return;
-    }
+    if (windowHeight === 0) return;
 
-    // open 상태가 변경되었을 때만 애니메이션 실행
     if (open !== lastOpenRef.current) {
       lastOpenRef.current = open || false;
 
       if (open) {
-        // 열린 상태로 애니메이션
         controls.start({
           y: calculatedValues.expandedY,
           transition: { type: 'spring', damping: 25, stiffness: 200 },
         });
         setCurrentY(calculatedValues.expandedY);
       } else {
-        // 닫힌 상태로 애니메이션
         controls.start({
           y: calculatedValues.collapsedY,
           transition: { type: 'spring', damping: 25, stiffness: 200 },
         });
         setCurrentY(calculatedValues.collapsedY);
-        // open이 false로 변경될 때 onClose 호출하지 않음 (무한 루프 방지)
       }
     }
   }, [open, windowHeight, calculatedValues, controls]);
 
   const handleDragEnd = (_: unknown, info: { point: { y: number } }) => {
     const { y } = info.point;
-    const threshold = 50; // 드래그 임계값
-
-    // 현재 위치에 따라 상태 결정
+    const threshold = 50;
     if (y < calculatedValues.middleY - threshold) {
-      // 위쪽으로 드래그하면 expanded 상태
       controls.start({
         y: calculatedValues.expandedY,
         transition: { type: 'spring', damping: 25, stiffness: 200 },
       });
       setCurrentY(calculatedValues.expandedY);
     } else if (y > calculatedValues.middleY + threshold) {
-      // 아래쪽으로 드래그하면 collapsed 상태 (닫기)
       controls.start({
         y: calculatedValues.collapsedY,
         transition: { type: 'spring', damping: 25, stiffness: 200 },
       });
       setCurrentY(calculatedValues.collapsedY);
-      // 드래그로 닫을 때 onClose 호출
       onClose?.();
     } else {
-      // 중간 영역이면 middle 상태로 이동
       controls.start({
         y: calculatedValues.middleY,
         transition: { type: 'spring', damping: 25, stiffness: 200 },
@@ -153,9 +102,7 @@ export const DragBottomSheet = ({
     }
   };
 
-  const handleSortClick = () => {
-    onSortClick?.();
-  };
+  const handleSortClick = () => onSortClick?.();
 
   const getSortLabel = (sortType: string) => {
     switch (sortType) {
@@ -170,10 +117,7 @@ export const DragBottomSheet = ({
     }
   };
 
-  // open이 false이면 렌더링하지 않음
-  if (!open) {
-    return null;
-  }
+  if (!open) return null;
 
   return (
     <motion.div
@@ -186,30 +130,26 @@ export const DragBottomSheet = ({
       style={{
         y: currentY,
         height: `calc(${windowHeight}px - ${currentY}px)`,
-        minHeight: '200px', // 최소 높이 설정
-        zIndex: 40, // 명시적으로 z-index 설정
+        minHeight: '200px',
+        zIndex: 40,
       }}
       className="fixed left-0 right-0 bottom-0 pointer-events-auto w-full max-w-[428px] mx-auto rounded-t-2xl border border-light-gray flex flex-col bg-[var(--main-2)]"
     >
-      {/* Header 부분 */}
+      {/* Header */}
       <div className="px-4 pt-4 pb-2">
         <div className="w-12 h-1.5 bg-gray rounded-full mx-auto" />
         <div className="flex items-center justify-start">
-          <div className="flex items-center gap-2 cursor-pointer" onClick={handleSortClick}>
+          <button className="flex items-center gap-2 cursor-pointer" onClick={handleSortClick}>
             <ArrowUpDown size={20} className="text-[var(--black)] font-body-semibold" />
             <div className="font-body-semibold text-[var(--black)]">
               {getSortLabel(currentSort)}
             </div>
-          </div>
+          </button>
         </div>
       </div>
 
-      {/* StoreCard 리스트 */}
-      <div
-        ref={scrollContainerRef}
-        onScroll={handleScroll}
-        className="flex-1 pb-36 overflow-y-auto custom-scrollbar"
-      >
+      {/* List (가상 스크롤) */}
+      <div className="flex-1 pb-36 overflow-hidden">
         {isLoading ? (
           <div className="flex flex-col items-center justify-center gap-3 px-4 pt-8 pb-6 min-h-[200px]">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
@@ -222,43 +162,37 @@ export const DragBottomSheet = ({
             </div>
           </div>
         ) : storeList && storeList.length > 0 ? (
-          <div className="flex flex-col items-center gap-3 px-4 pt-3 pb-6">
-            {storeList.map((store, idx) => {
-              const itemKey = `${store.id || `item-${idx}`}`;
-              const isNewItem = animatedItems.has(itemKey);
-              const isInitialLoad = idx < 5; // 초기 로드된 아이템들
-
-              // 초기 로드된 아이템들은 순차 애니메이션, 새로 로드된 아이템들은 즉시 애니메이션
-              const staggerClass = isInitialLoad
-                ? `animate-stagger-${Math.min(idx + 1, 5)}`
-                : 'animate-slide-in-up';
-
-              // 새로 로드된 아이템들은 즉시 애니메이션 적용
-              const animationClass =
-                isNewItem && !isInitialLoad
-                  ? 'animate-slide-in-up animate-fade-in'
-                  : `animate-slide-in-up ${staggerClass}`;
-
-              return (
-                <div key={itemKey} className={`w-full ${animationClass}`}>
-                  <StoreCard {...store} />
+          <Virtuoso
+            data={storeList}
+            computeItemKey={(_, card) => card.id}
+            increaseViewportBy={{ top: 400, bottom: 800 }}
+            itemContent={(_, card) => (
+              <div className="flex items-center justify-center px-4 pt-3 pb-3">
+                <div className="w-full">
+                  <StoreCard {...card} />
                 </div>
-              );
-            })}
-            {/* 무한 스크롤 로딩 인디케이터 */}
-            {isFetchingNextPage && (
-              <div className="text-center text-[var(--gray-dark)] py-4 animate-fade-in">
-                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500 mx-auto mb-2"></div>
-                더 많은 스토어를 불러오는 중...
               </div>
             )}
-            {/* 더 이상 데이터가 없을 때 */}
-            {!hasNextPage && storeList.length > 0 && (
-              <div className="text-center text-[var(--gray-dark)] py-4 animate-fade-in">
-                모든 스토어를 불러왔습니다.
-              </div>
-            )}
-          </div>
+            endReached={() => {
+              if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
+            }}
+            components={{
+              Footer: () =>
+                isFetchingNextPage ? (
+                  <div className="text-center text-[var(--gray-dark)] py-4">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500 mx-auto mb-2"></div>
+                    더 많은 스토어를 불러오는 중...
+                  </div>
+                ) : hasNextPage ? (
+                  <div className="h-6" />
+                ) : (
+                  <div className="text-center text-[var(--gray-dark)] py-4">
+                    모든 스토어를 불러왔습니다.
+                  </div>
+                ),
+            }}
+            // defaultItemHeight={136}
+          />
         ) : (
           <div className="flex flex-col items-center justify-center gap-3 px-4 pt-8 pb-6 min-h-[200px]">
             <div className="text-center text-[var(--gray-dark)]">표시할 스토어가 없습니다.</div>

--- a/src/features/rental/map/ui/StoreCard.tsx
+++ b/src/features/rental/map/ui/StoreCard.tsx
@@ -1,4 +1,7 @@
+// src/features/rental/map/ui/StoreCard.tsx
 'use client';
+
+import React, { memo } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -10,10 +13,9 @@ import { StoreLikeButton } from '@/shared/ui/StoreLikeButton';
 
 import type { StoreCardProps } from '@/features/rental/map/lib/types';
 
-// 유틸 함수는 컴포넌트 바깥으로 분리
 const formatTime = (time: string) => time.substring(0, 5);
 
-export function StoreCard({
+function StoreCardBase({
   store,
   storeDetail,
   deviceCount,
@@ -47,21 +49,16 @@ export function StoreCard({
       className={`w-[380px] bg-white rounded-[16px] p-3 flex gap-3 shadow-sm relative items-start cursor-pointer hover:shadow-md transition-shadow ${className ?? ''}`}
       onClick={handleCardClick}
     >
-      {/* 왼쪽: 스토어 이미지 */}
-      <ImageBox
-        size="xs"
-        url={storeDetail.imageUrl} // 기본 이미지 설정
-      />
-      {/* 중앙: content 영역 */}
+      <ImageBox size="xs" url={storeDetail.imageUrl} />
+
       <div className="flex flex-col flex-1 h-[68px] justify-between min-w-0">
-        {/* 타이틀: 상단 고정 - 길면 ... 처리 */}
         <h3 className="text-black font-small-regular truncate">{store.name}</h3>
-        {/* 영업 상태 및 시간: 가운데 */}
+
         <p className="font-small-regular text-black truncate">
           {operatingStatus} · {formatTime(storeDetail.startTime)} ~{' '}
           {formatTime(storeDetail.endTime)}
         </p>
-        {/* 거리/주소/남은 공유기: 하단 고정 */}
+
         <div className="flex gap-2">
           <div className="flex items-end gap-2 flex-1 min-w-0">
             {showDistance && (
@@ -78,11 +75,11 @@ export function StoreCard({
           </div>
         </div>
       </div>
-      {/* 오른쪽 상단 좋아요 버튼 */}
+
       <div
         className="absolute right-3 top-3"
         onClick={(e) => {
-          e.stopPropagation(); // 카드 클릭 이벤트 전파 방지
+          e.stopPropagation();
           handleLikeToggle();
         }}
       >
@@ -96,3 +93,25 @@ export function StoreCard({
     </div>
   );
 }
+
+// 실제 렌더에 사용하는 필드만 비교(얕은 비교)
+const areEqual = (
+  a: Readonly<React.ComponentProps<typeof StoreCardBase>>,
+  b: Readonly<React.ComponentProps<typeof StoreCardBase>>,
+) =>
+  a.isLiked === b.isLiked &&
+  a.deviceCount === b.deviceCount &&
+  a.className === b.className &&
+  a.showDistance === b.showDistance &&
+  a.disableToast === b.disableToast &&
+  a.onLikeToggle === b.onLikeToggle && // 상위에서 useCallback 권장
+  a.store.id === b.store.id &&
+  a.store.name === b.store.name &&
+  a.storeDetail.imageUrl === b.storeDetail.imageUrl &&
+  a.storeDetail.detailAddress === b.storeDetail.detailAddress &&
+  a.storeDetail.isOpening === b.storeDetail.isOpening &&
+  a.storeDetail.startTime === b.storeDetail.startTime &&
+  a.storeDetail.endTime === b.storeDetail.endTime &&
+  a.storeDetail.distanceFromMe === b.storeDetail.distanceFromMe;
+
+export const StoreCard = memo(StoreCardBase, areEqual);

--- a/src/features/rental/store/review/ui/ReviewItem.tsx
+++ b/src/features/rental/store/review/ui/ReviewItem.tsx
@@ -11,7 +11,7 @@ import { PATH } from '@/shared/config/path';
 import { Drawer, DrawerButton } from '@/shared/ui/Drawer';
 import { Profile } from '@/shared/ui/Profile';
 
-import type { ReviewItem as ReviewItemType } from '@/features/rental/store/review/lib/types.ts';
+import type { ReviewItem as ReviewItemType } from '@/features/rental/store/review/lib/types';
 
 interface ReviewItemProps {
   review: ReviewItemType;

--- a/src/shared/ui/ImageBox/ImageBox.tsx
+++ b/src/shared/ui/ImageBox/ImageBox.tsx
@@ -1,4 +1,7 @@
 'use client';
+import { useState } from 'react';
+
+import Image from 'next/image';
 
 import { ICONS } from '@/shared/config/iconPath';
 import { cn } from '@/shared/lib/cn';
@@ -11,15 +14,31 @@ const SIZE_MAP: Record<ImageBoxSize, string> = {
   md: 'w-[140px] h-[140px]',
   lg: 'w-[161px] h-[161px]',
 };
+const SIZE_PX: Record<ImageBoxSize, { w: number; h: number }> = {
+  xs: { w: 68, h: 68 },
+  sm: { w: 100, h: 100 },
+  md: { w: 140, h: 140 },
+  lg: { w: 161, h: 161 },
+};
 
 interface ImageBoxProps {
   size?: ImageBoxSize;
   url?: string;
   className?: string;
+  alt?: string;
+  /** 히어로 이미지(상단 1~2개 정도)만 true → LCP 개선 */
+  priority?: boolean;
 }
 
-export function ImageBox({ size = 'sm', url, className }: ImageBoxProps) {
-  const fallbackImage = ICONS.LOGO.SAMPLE;
+export function ImageBox({
+  size = 'sm',
+  url,
+  className,
+  alt = 'image',
+  priority = false,
+}: ImageBoxProps) {
+  const fallbackUrl = typeof ICONS.LOGO.SAMPLE === 'string' ? ICONS.LOGO.SAMPLE : ICONS.LOGO.SAMPLE;
+  const [src, setSrc] = useState(url || fallbackUrl);
 
   // xs 크기일 때는 radius를 10px로 설정
   const borderRadius = size === 'xs' ? 'rounded-[10px]' : 'rounded-[24px]';
@@ -34,7 +53,18 @@ export function ImageBox({ size = 'sm', url, className }: ImageBoxProps) {
         className,
       )}
     >
-      <img src={url || fallbackImage} alt="image" className="object-cover w-full h-full" />
+      <Image
+        src={src}
+        alt={alt}
+        width={SIZE_PX[size].w}
+        height={SIZE_PX[size].h}
+        sizes={`${SIZE_PX[size].w}px`}
+        style={{ width: `${SIZE_PX[size].w}px`, height: `${SIZE_PX[size].h}px` }}
+        priority={priority} // 히어로만 true
+        fetchPriority={priority ? 'high' : 'auto'} // 네트워크 스케줄러 힌트
+        onError={() => setSrc(fallbackUrl)}
+        className="object-cover w-full h-full"
+      />
     </div>
   );
 }

--- a/src/shared/ui/StoreLikeButton/StoreLikeButton.tsx
+++ b/src/shared/ui/StoreLikeButton/StoreLikeButton.tsx
@@ -1,3 +1,5 @@
+import React, { memo } from 'react';
+
 import Image from 'next/image';
 
 import { ICONS } from '@/shared/config/iconPath';
@@ -5,30 +7,21 @@ import { ICONS } from '@/shared/config/iconPath';
 interface StoreLikeButtonProps {
   isLiked: boolean;
   isLoading?: boolean;
-  onClick: (e: React.MouseEvent) => void;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
   className?: string;
   size?: 'sm' | 'md' | 'lg';
 }
 
-export function StoreLikeButton({
+const sizeClasses = { sm: 'w-6 h-6', md: 'w-8 h-8', lg: 'w-10 h-10' } as const;
+const imageSize = { sm: 21, md: 28, lg: 35 } as const;
+
+function StoreLikeButtonBase({
   isLiked,
   isLoading = false,
   onClick,
   className = '',
   size = 'sm',
 }: StoreLikeButtonProps) {
-  const sizeClasses = {
-    sm: 'w-6 h-6',
-    md: 'w-8 h-8',
-    lg: 'w-10 h-10',
-  };
-
-  const imageSize = {
-    sm: 21,
-    md: 28,
-    lg: 35,
-  };
-
   return (
     <div
       className={`rounded-full bg-white flex items-center justify-center shadow-lg ${sizeClasses[size]} ${className}`}
@@ -59,3 +52,12 @@ export function StoreLikeButton({
     </div>
   );
 }
+
+const eq = (a: StoreLikeButtonProps, b: StoreLikeButtonProps) =>
+  a.isLiked === b.isLiked &&
+  a.isLoading === b.isLoading &&
+  a.size === b.size &&
+  a.className === b.className &&
+  a.onClick === b.onClick; // 부모에서 useCallback으로 고정 권장
+
+export const StoreLikeButton = memo(StoreLikeButtonBase, eq);


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #290 

## 1) 도입 배경

대용량 가맹점 목록에서 무한스크롤로 DOM이 누적되고, DragBottomSheet 상호작용마다 리스트 전체 리렌더가 발생해 프레임 타임이 불안정했습니다. 또한 썸네일 로딩 중 레이아웃 시프트(CLS) 가 발생하고, 이미지 네트워크 지연으로 초기 체감 LCP가 길었습니다.

</br>

## 2) 작업 내용
### 1. 목록 가상화 (react-vrituoso) 도입
- 무한스크롤 대신 `가상 스크롤(react-virtuoso)` 적용
- `뷰포트 ± overscan`만 DOM에 유지, `endReached`로 패칭 단순화, `computeItemKey(id)`로 DOM 재사용 극대화.

### 2. 프롭 안정화 + 메모화
- 아이템 단위 캐시(Map): StoreListItem 를  `StoreCardProps 변환 시 동일 값이면 이전 객체 참조 재사용`하도록 변경
- StoreCard/StoreLikeButton: React.memo + 실사용 필드 기준 비교.
- 상위 콜백 useCallback 고정하여 리렌더 방지

### 3. 드로워 드래그 성능
- `rAF` 배치 + motionValue: 드래그 중 위치 업데이트를 프레임당 1회로 묶고, y/height를 state 대신 `motionValue로 관리`(드래그 중 React 렌더 0회).

### 4. LCP/CLS 개선 (이미지)
- next/image + width/height + sizes로 레이아웃 선점(CLS 0).
- 히어로 썸네일에만 priority/fetchPriority=high, 그 외 lazy/async.
- `이미지 CDN preconnect`로 DNS/TCP/TLS 지연 선제 제거.

</br>

## 3) 핵심 코드 스니펫

#### 1. Virtuoso 적용

```ts
<Virtuoso
  data={storeList}
  computeItemKey={(_, card) => card.id}
  increaseViewportBy={{ top: 400, bottom: 800 }}
  endReached={handleEndReached}
  itemContent={(_, card) => (
    <div className="px-4 pt-3 pb-3">
      <StoreCard {...card} />
    </div>
  )}
/>
```

#### 2. 아이템 단위 캐시(Map)

```ts
const cacheRef = useRef<Map<number, StoreCardProps>>(new Map());
const cards = useMemo(() => stores.map(s => {
  const prev = cacheRef.current.get(s.id);
  const next = toCardProps(s);
  if (prev && shallowEqual(prev, next)) return prev; // 참조 재사용
  cacheRef.current.set(s.id, next);
  return next;
}), [stores]);
```


#### 3. StoreCard 메모화 + 커스텀 비교

```ts
export const StoreCard = memo(StoreCardBase, (a, b) =>
  a.deviceCount === b.deviceCount &&
  a.isLiked === b.isLiked &&
  a.onLikeToggle === b.onLikeToggle &&
  a.store.id === b.store.id &&
  a.store.name === b.store.name &&
  a.storeDetail.imageUrl === b.storeDetail.imageUrl &&
  a.storeDetail.detailAddress === b.storeDetail.detailAddress &&
  a.storeDetail.isOpening === b.storeDetail.isOpening &&
  a.storeDetail.startTime === b.storeDetail.startTime &&
  a.storeDetail.endTime === b.storeDetail.endTime &&
  a.storeDetail.distanceFromMe === b.storeDetail.distanceFromMe
);
```

#### 4. rAF 스로틀 + motionValue

```ts
const y = useMotionValue(0);
const heightMV = useTransform(y, v => `calc(${windowHeight}px - ${v}px)`);
const onDragRaf = useRafThrottle<[MouseEvent|TouchEvent|PointerEvent, PanInfo]>(
  (_e, info) => y.set(Math.max(0, Math.min(info.point.y, windowHeight)))
);

<motion.div
  onDrag={onDragRaf}
  style={{ y, height: heightMV, willChange: 'transform,height' }}
/>
```

#### 5. ImageBox (next/image + 레이아웃 선점)

```ts
<Image
  src={src}
  alt={alt}
  width={w} height={h}     // 레이아웃 선점 → CLS 0
  sizes={`${w}px`}
  priority={priority}       // 히어로만 true
  fetchPriority={priority ? 'high' : 'auto'}
  onError={() => setSrc(fallbackUrl)}
  className="object-cover w-full h-full"
/>
```

</br>


## 4) 성능 최적화 전후 비교

### Before vs After

| Before | After |
|--------|-------|
| **DragBottomSheet 상태 변경 시 전체 리스트 리렌더**<br/>StoreCard 다수 동시 렌더링 (531~707ms) | **StoreCard 메모화 + props 안정화 + 가상 스크롤 적용**<br/>DragBottomSheet Commit 시간 0.7ms 수준으로 단축 |
| <img width="1229" height="774" alt="before1" src="https://github.com/user-attachments/assets/10cd97c8-3d52-4610-8423-681a8e6af56d" /> | <img width="828" height="426" alt="after1" src="https://github.com/user-attachments/assets/68070668-3c0b-42ba-aef2-fea10208dcb8" /> |
| **이미지 늦은 로드 → 레이아웃 변경 발생**<br/>CLS 0.23 | **CDN preconnect + ImageBox 높이 고정 + priority 적용**<br/>CLS 0.00 |
| <img width="731" height="403" alt="image" src="https://github.com/user-attachments/assets/19d26a43-2cca-4751-91bf-3c261fd904d6" />| <img width="703" height="441" alt="image" src="https://github.com/user-attachments/assets/c4908cbc-91c2-41d3-8dc5-fde4be35d534" />|
| **프레임 다수에서 커밋 발생 (~15–25회/초)** | **대부분 프레임에서 커밋 0회**<br/>간헐적 2–5회/초 수준으로 감소 |
| <img width="1148" height="593" alt="image" src="https://github.com/user-attachments/assets/79a2cfb6-87f8-4477-9577-e79e28662b94" /> |<img width="1196" height="593" alt="image" src="https://github.com/user-attachments/assets/88b25e56-e688-49db-810c-96b2491e178e" /> |

---

### 성과 수치 (실측 기반)

| 지표                 | Before | After | 개선 효과 |
|----------------------|--------|-------|-----------|
| **Commit 시간(평균)** | 531–707 ms (DragBottomSheet) | ~0.7 ms | ↓ **99% 이상** |
| **Commit p95**       | ~801 ms | ~220 ms 이하 | ↓ 대폭 감소 |
| **드래그 중 커밋 빈도** | 15–25회/초 | 0–5회/초 | ↓ 80–90% |
| **JS 힙 변동폭**      | ±20MB 이상 | ±5MB 내 | GC 압박 완화 |
| **CLS**              | 0.23 | 0.00 | –0.23 (완전 제거) |
| **INP**              | 98 ms | 80 ms | –18 ms (~18% 개선) |
| **LCP**              | 불안정 (이미지 지연 로드) | 안정화 (priority 적용) | 첫 화면 체감 개선 |



### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

### ✅ Check List

- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
