### PR TITLE
Performance: 위치 검색창 디바운스·AbortController 적용으로 중복 요청 제거

### DIFF
--- a/src/features/rental/search/hook/useSearchPlacesHooks.ts
+++ b/src/features/rental/search/hook/useSearchPlacesHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   searchPlaces,
@@ -32,6 +32,9 @@ export const useSearchPlaces = () => {
   const [hasNext, setHasNext] = useState(true);
   const [page, setPage] = useState(1);
 
+  // 같은 요청 (키워드, 페이지)이 중복으로 발생하는 것을 방지 가드
+  const lastReqRef = useRef<string | null>(null);
+
   // 디바운스된 키워드 (500ms) - 공백 제거
   const debouncedKeyword = useDebounce(keyword.trim(), 500);
 
@@ -43,6 +46,13 @@ export const useSearchPlaces = () => {
         setSearchResults([]);
         return;
       }
+
+      // StrictMode 재마운트/이펙트 재실행 시 같은 요청 스킵
+      const reqKey = `${trimmedKeyword}::${pageNum}::${append ? 'append' : 'replace'}`;
+      if (lastReqRef.current === reqKey) {
+        return;
+      }
+      lastReqRef.current = reqKey;
 
       if (pageNum === 1) {
         setIsLoading(true);

--- a/src/features/rental/search/hook/useSearchPlacesHooks.ts
+++ b/src/features/rental/search/hook/useSearchPlacesHooks.ts
@@ -38,6 +38,9 @@ export const useSearchPlaces = () => {
   // 디바운스된 키워드 (500ms) - 공백 제거
   const debouncedKeyword = useDebounce(keyword.trim(), 500);
 
+  // 이전 요청 취소용 컨트롤러
+  const controllerRef = useRef<AbortController | null>(null);
+
   // 검색 실행 함수
   const performSearch = useCallback(
     async (searchKeyword: string, pageNum: number = 1, append: boolean = false) => {
@@ -54,6 +57,13 @@ export const useSearchPlaces = () => {
       }
       lastReqRef.current = reqKey;
 
+      // 이전 요청 취소
+      controllerRef.current?.abort();
+      // 새 컨트롤러 생성
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      // API 호출
       if (pageNum === 1) {
         setIsLoading(true);
       } else {
@@ -65,6 +75,7 @@ export const useSearchPlaces = () => {
           keyword: trimmedKeyword,
           page: pageNum,
           size: 15,
+          signal: controller.signal,
         };
 
         const results = await searchPlaces(params);
@@ -77,13 +88,15 @@ export const useSearchPlaces = () => {
 
         setHasNext(results.length === 15 && pageNum < 3);
       } catch (error) {
-        console.error('검색 오류:', error);
-        if (!append) {
-          setSearchResults([]);
-        }
-        // API 호출 제한 에러인 경우 사용자에게 알림
-        if (error instanceof Error && error.message.includes('API 호출 제한')) {
-          console.warn('API 호출 제한으로 인해 검색이 일시적으로 중단되었습니다.');
+        if ((error as Error)?.name !== 'AbortError') {
+          console.error('검색 오류:', error);
+          if (!append) {
+            setSearchResults([]);
+          }
+          // API 호출 제한 에러인 경우 사용자에게 알림
+          if (error instanceof Error && error.message.includes('API 호출 제한')) {
+            console.warn('API 호출 제한으로 인해 검색이 일시적으로 중단되었습니다.');
+          }
         }
       } finally {
         setIsLoading(false);
@@ -97,11 +110,17 @@ export const useSearchPlaces = () => {
   useEffect(() => {
     if (!debouncedKeyword) {
       setSearchResults([]);
+      // 현재 진행 중인 요청이 있으면 취소
+      controllerRef.current?.abort();
       return;
     }
     setPage(1);
     setHasNext(true);
     performSearch(debouncedKeyword, 1, false);
+    // 이 이펙트가 재실행/언마운트 될 때 진행 중 요청 취소
+    return () => {
+      controllerRef.current?.abort();
+    };
   }, [debouncedKeyword, performSearch]);
 
   // 다음 페이지 로드 함수

--- a/src/features/rental/search/hook/useSearchPlacesHooks.ts
+++ b/src/features/rental/search/hook/useSearchPlacesHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   searchPlaces,
@@ -21,22 +21,6 @@ const useDebounce = (value: string, delay: number) => {
   }, [value, delay]);
 
   return debouncedValue;
-};
-
-// 스로틀링 훅
-const useThrottle = <T extends unknown[]>(callback: (...args: T) => void, delay: number) => {
-  const lastRunRef = useRef(0);
-
-  return useCallback(
-    (...args: T) => {
-      const now = Date.now();
-      if (now - lastRunRef.current >= delay) {
-        lastRunRef.current = now;
-        callback(...args);
-      }
-    },
-    [callback, delay],
-  );
 };
 
 // 키워드 검색 훅
@@ -99,19 +83,16 @@ export const useSearchPlaces = () => {
     [],
   );
 
-  // 스로틀링된 검색 함수 (300ms)
-  const throttledSearch = useThrottle(performSearch, 300);
-
   // 디바운스된 키워드가 변경될 때 검색 실행
   useEffect(() => {
-    if (debouncedKeyword) {
-      setPage(1);
-      setHasNext(true);
-      throttledSearch(debouncedKeyword, 1, false);
-    } else {
+    if (!debouncedKeyword) {
       setSearchResults([]);
+      return;
     }
-  }, [debouncedKeyword, throttledSearch]);
+    setPage(1);
+    setHasNext(true);
+    performSearch(debouncedKeyword, 1, false);
+  }, [debouncedKeyword, performSearch]);
 
   // 다음 페이지 로드 함수
   const loadNextPage = useCallback(() => {

--- a/src/features/rental/search/hook/useSearchPosHooks.ts
+++ b/src/features/rental/search/hook/useSearchPosHooks.ts
@@ -50,28 +50,25 @@ export const useSearchPos = () => {
   } = useSearchPlaces();
 
   // 검색 결과 선택 시 호출되는 함수
-  const handleSelectPlace = useCallback(
-    (place: PlaceSearchResult) => {
-      createAddressMutation.mutate(place, {
-        onSuccess: () => {
-          setTimeout(() => {
-            queryClient.invalidateQueries({ queryKey: ['addressHistory', 5, sort] });
-            refetch();
-          }, 500);
-        },
-      });
+  const handleSelectPlace = useCallback((place: PlaceSearchResult) => {
+    createAddressMutation.mutate(place, {
+      onSuccess: () => {
+        setTimeout(() => {
+          queryClient.invalidateQueries({ queryKey: ['addressHistory', 5, sort] });
+          refetch();
+        }, 500);
+      },
+    });
 
-      const searchParams = new URLSearchParams({
-        lat: place.y.toString(),
-        lng: place.x.toString(),
-        address: place.road_address_name || place.address_name,
-        placeName: place.place_name,
-      });
+    const searchParams = new URLSearchParams({
+      lat: place.y.toString(),
+      lng: place.x.toString(),
+      address: place.road_address_name || place.address_name,
+      placeName: place.place_name,
+    });
 
-      router.push(`/rental?${searchParams.toString()}`);
-    },
-    [createAddressMutation, refetch, sort, queryClient, router],
-  );
+    router.push(`/rental?${searchParams.toString()}`);
+  }, []);
 
   // 주소 이력 클릭 시 호출되는 함수
   const handleAddressHistoryClick = useCallback(

--- a/src/features/rental/search/hook/useSearchPosHooks.ts
+++ b/src/features/rental/search/hook/useSearchPosHooks.ts
@@ -49,26 +49,39 @@ export const useSearchPos = () => {
     loadNextPage,
   } = useSearchPlaces();
 
-  // 검색 결과 선택 시 호출되는 함수
-  const handleSelectPlace = useCallback((place: PlaceSearchResult) => {
-    createAddressMutation.mutate(place, {
-      onSuccess: () => {
-        setTimeout(() => {
-          queryClient.invalidateQueries({ queryKey: ['addressHistory', 5, sort] });
-          refetch();
-        }, 500);
-      },
-    });
+  // 주소 이력 쿼리 키
+  const addressHistoryKey = (limit: number, sort: string /*, userId?: string */) =>
+    ['addressHistory', limit, sort /*, userId */] as const;
 
-    const searchParams = new URLSearchParams({
-      lat: place.y.toString(),
-      lng: place.x.toString(),
-      address: place.road_address_name || place.address_name,
-      placeName: place.place_name,
-    });
+  const LIMIT = 5;
 
-    router.push(`/rental?${searchParams.toString()}`);
-  }, []);
+  // 장소 선택 시 호출되는 함수
+  const handleSelectPlace = useCallback(
+    async (place: PlaceSearchResult) => {
+      try {
+        // 1) 주소 생성(저장)
+        await createAddressMutation.mutateAsync(place);
+
+        // 2) 캐시 무효화 + 즉시 재패치 (타임아웃 제거)
+        const key = addressHistoryKey(LIMIT, sort);
+        await queryClient.invalidateQueries({ queryKey: key });
+        await queryClient.refetchQueries({ queryKey: key });
+
+        // 3) 라우팅
+        const searchParams = new URLSearchParams({
+          lat: String(place.y), // Kakao: y=lat, x=lng
+          lng: String(place.x),
+          address: place.road_address_name || place.address_name,
+          placeName: place.place_name,
+        });
+        router.push(`/rental?${searchParams.toString()}`);
+      } catch (e) {
+        // 필요 시 토스트/로그
+        console.error(e);
+      }
+    },
+    [createAddressMutation, queryClient, sort, router],
+  );
 
   // 주소 이력 클릭 시 호출되는 함수
   const handleAddressHistoryClick = useCallback(

--- a/src/features/rental/search/hook/useSearchPosHooks.ts
+++ b/src/features/rental/search/hook/useSearchPosHooks.ts
@@ -179,17 +179,14 @@ export const useSearchPos = () => {
     }
   }, [throttledHandleScroll]);
 
-  // 주소 이력 존재 여부
+  // 주소 이력 존재 여부 (실제 내용이 바뀔 때만 재계산)
   const hasAddressHistory = useMemo(() => {
-    return (
-      Array.isArray(addressHistoryInfinite?.pages) &&
-      addressHistoryInfinite.pages.some(
-        (page) =>
-          Array.isArray(page?.content?.getAddressResponses) &&
-          page.content.getAddressResponses.length > 0,
-      )
+    if (!addressHistoryInfinite?.pages) return false;
+
+    return addressHistoryInfinite.pages.some(
+      (page) => page?.content?.getAddressResponses?.length > 0,
     );
-  }, [addressHistoryInfinite?.pages]);
+  }, [addressHistoryInfinite]);
 
   return {
     // 상태

--- a/src/features/rental/search/utils/address/searchPlaces.ts
+++ b/src/features/rental/search/utils/address/searchPlaces.ts
@@ -14,11 +14,12 @@ export interface SearchPlacesParams {
   keyword: string;
   page?: number;
   size?: number;
+  signal?: AbortSignal;
 }
 
 // 키워드 검색 함수 (페이지네이션 지원)
 export const searchPlaces = async (params: SearchPlacesParams): Promise<PlaceSearchResult[]> => {
-  const { keyword, page = 1, size = 15 } = params;
+  const { keyword, page = 1, size = 15, signal } = params;
 
   if (!keyword.trim()) {
     return [];
@@ -31,6 +32,7 @@ export const searchPlaces = async (params: SearchPlacesParams): Promise<PlaceSea
         headers: {
           Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_MAP_REST_API_KEY}`,
         },
+        signal, //진행 중 요청을 취소할 수 있도록 signal 추가
       },
     );
 
@@ -67,7 +69,11 @@ export const searchPlaces = async (params: SearchPlacesParams): Promise<PlaceSea
 
     return [];
   } catch (error) {
+    if ((error as Error)?.name === 'AbortError') {
+      // 요청이 취소된 경우 (AbortError)에는 아무 작업도 하지 않음
+      throw error;
+    }
     console.error('키워드 검색 오류:', error);
-    return [];
+    throw error;
   }
 };


### PR DESCRIPTION
### #️⃣ 연관된 이슈
> close: #297

</br>

## 1) 도입 배경

위치 검색창 입력 시 디바운싱과 쓰로틀링을 중첩 적용하여, 사용자가 `서울시 강남구` 등 한글을 타이핑할 때마다 **최대 22회의 API 호출**이 발생했습니다.  
React 18의 StrictMode 더블 마운트와 AbortController 부재로 인해 **모든 요청이 완료될 때까지 진행되어**, 불필요한 네트워크 비용 및 렌더링 과부하가 발생했습니다.

### 주요 문제점
1. `디바운스 + 쓰로틀` 중첩으로 멈춤마다 1회 + 경계 1회 추가 호출
2. StrictMode의 마운트/언마운트로 ref 초기화 → 동일 요청 중복 발화
3. AbortController 미적용으로 이전 요청 미취소 (in-flight 요청 중첩)
4. INP 111 ms / 전체 타임라인 5995 ms 로 사용자 체감 지연 심화

</br>

## 2) 작업 내용

### 1️⃣ 디바운스 단일화
- 쓰로틀 훅(`useThrottle`) 완전 제거  
- “최종 확정값 1회 호출” 흐름으로 단순화  

### 2️⃣ StrictMode 중복 호출 가드
- `lastReqRef` 도입 → `(keyword, page, append)` 조합으로 요청 키 생성  
- 동일 키 연속 호출 시 조기 return  

### 3️⃣ AbortController 적용
- `controllerRef`로 이전 요청 추적  
- 새 요청 시 `abort()`로 기존 요청 강제 취소  
- `signal`을 fetch 옵션에 전달해 중간 요청 즉시 중단  
- `useEffect` clean-up 시점에서도 abort 실행  

</br>

## 3) 핵심 코드 스니펫

#### ✅ 1. 디바운스 단일화 (스로틀 제거)
```ts
useEffect(() => {
  if (!debouncedKeyword) {
    setSearchResults([]);
    return;
  }
  setPage(1);
  setHasNext(true);
  performSearch(debouncedKeyword, 1, false);
}, [debouncedKeyword, performSearch]);
```
#### ✅ 2. StrictMode 중복 호출 가드
```ts
const lastReqRef = useRef<string | null>(null);

const performSearch = useCallback(async (keyword: string, pageNum = 1, append = false) => {
  const trimmed = keyword.trim();
  const reqKey = `${trimmed}::${pageNum}::${append ? 'append' : 'replace'}`;
  if (lastReqRef.current === reqKey) return;  // 중복 요청 차단
  lastReqRef.current = reqKey;
  // ...
}, []);
```
#### ✅ 3. AbortController 도입
```ts

const controllerRef = useRef<AbortController | null>(null);

const performSearch = useCallback(async (keyword: string, pageNum = 1, append = false) => {
  controllerRef.current?.abort(); // 이전 요청 중단
  const controller = new AbortController();
  controllerRef.current = controller;

  const params = { keyword, page: pageNum, size: 15, signal: controller.signal };
  try {
    const results = await searchPlaces(params);
    // ...
  } catch (err: any) {
    if (err.name !== 'AbortError') console.error('검색 오류:', err);
  }
}, []);

```
#### ✅ 4. fetch signal 전달
```ts
export const searchPlaces = async ({ keyword, page = 1, size = 15, signal }: SearchPlacesParams) => {
  const res = await fetch(
    `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(keyword)}&page=${page}&size=${size}`,
    {
      headers: { Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_MAP_REST_API_KEY}` },
      signal, // 요청 취소 신호 연결
    },
  );
  return res.json();
};
```
</br>
</br>

## 성능 최적화 전후 비교

###  1. API 호출 횟수 개선 및 네트워크 요청 중첩 제거
- 디바운스 + 쓰로틀 중첩으로 최대 **22회 API 호출** 발생 | **디바운스 단일화 + AbortController 적용 → 1회로 단일화**
- 이전 요청이 완료될 때까지 모두 유지 (in-flight 22건) | 새 요청 전 **abort()** 실행으로 즉시 중단 

| Before | After |
|--------|-------|
| 이전 요청이 완료될 때까지 모두 유지 (in-flight 22건) | 새 요청 전 **abort()** 실행으로 즉시 중단 |
|<img width="1116" height="692" alt="image" src="https://github.com/user-attachments/assets/4e72168c-ebda-4fda-bf7b-31ca4c0375bd" /> | <img width="1048" height="435" alt="image" src="https://github.com/user-attachments/assets/3aa32a95-6424-4732-94ad-70c7d4028085" /> |

---

### 2. 전체 타임라인 범위 감소 및 INP(입력 응답 시간) 개선
- **111 ms** — 입력 시 지연 발생, 메인 스레드 과부하 | **48 ms** — 반응 즉시 렌더링, 부드러운 타이핑

| Before | After |
|--------|-------|
| **Full Range: 5995 ms** — 연속 JS 실행으로 긴 차트 | **Full Range: 2506 ms** — 불필요한 실행 절반 이하로 감소 |
| <img width="1023" height="666" alt="image" src="https://github.com/user-attachments/assets/e9f5063f-b6e1-4e03-b1e3-4440a574af16" /> |<img width="953" height="535" alt="image" src="https://github.com/user-attachments/assets/9ea490bf-9245-4dbd-839e-890b8a637cfb" /> |

</br>

###  5. 요약 수치 비교

| 지표 | Before | After | 개선율 |
|------|--------|--------|--------|
| **API 호출 횟수** | 22회 | 1회 | –95 % |
| **INP (입력 지연)** | 111 ms | 48 ms | –57 % |
| **Full Range** | 5995 ms | 2506 ms | –58 % |
| **중첩 요청 수** | 10 건 이상 | 0 건 | –100 % |

</br>

> 💡 **결과 요약:**  
> 불필요한 API 호출과 in-flight 요청을 모두 제거하면서,  
> 사용자의 입력 지연(INP)을 57% 단축하고 렌더링 범위를 절반 이하로 줄였습니다.


